### PR TITLE
chore: gitignore Alfred runtime state files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ vendor/
 
 # Rust
 target/
+
+# Alfred runtime state
+.claude/.session-count
+.claude/.onboarding-state.json
+.claude/.session-bookmark.json


### PR DESCRIPTION
Session count, onboarding state, and session bookmarks are runtime
artifacts that vary per user and should not be tracked in version control.

https://claude.ai/code/session_012K8WNnS5o1nyZWQ7pbippY