### PR TITLE
Add jargon-free pitch doc for non-technical audiences

### DIFF
--- a/docs/PITCH.md
+++ b/docs/PITCH.md
@@ -1,0 +1,128 @@
+# Alfred
+
+## What it is
+
+Alfred is a personal coach for working with AI — one that's designed to disappear.
+
+AI assistants can do the technical work: writing code, analyzing data, generating reports, setting up projects. What they can't do is give you the habits that make the work hold up — saving your progress regularly, trying ideas safely without breaking what already works, keeping track of how you got a result, picking up where you left off.
+
+Alfred teaches you those habits in language you already understand, protects you from common mistakes automatically, and learns from your corrections to reshape your environment over time. Then it gets out of the way. The measure of success isn't how much you use Alfred — it's how little.
+
+## The problem
+
+People don't fail at AI-assisted work because the AI is bad. They fail because nothing around it enforces good habits.
+
+They forget to save their work and lose an hour of progress. They experiment on the live version and break it. They get a great result and can't explain how. They close a session and forget what they were doing.
+
+These aren't hard skills. They're easy ones — easy to learn, easier to skip. And skipping them is how you end up with lost work, broken projects, and results nobody can reproduce.
+
+## How it works
+
+You answer a few questions — what kind of work you do, how comfortable you are with technical tools, and what you're building. Alfred sets up everything else.
+
+What happens next depends on who you are. But behind the scenes, three things are always running: **teaching that fades, automation that grows, and a self-improvement loop that learns from you.** The balance between them shifts over time — and by the end, the teaching is gone, the automation handles the rest, and your corrections have reshaped the system to fit exactly how you work.
+
+---
+
+### If you're a beginner: zero to building
+
+You've never done this before. You opened this because someone said "AI can help you build things" and you wanted to try.
+
+Alfred meets you there.
+
+**It speaks your language.** When Alfred teaches you to save your work frequently, it doesn't use technical terms. It uses language from your field. A data scientist hears "checkpoint your experiment — just like saving your model so you can pick up from where you left off." A business analyst hears "save a new version of the spreadsheet — so you can always go back to the one you shared with the VP." A researcher hears "sign a page in your lab notebook — creating a record that can't be altered after the fact."
+
+Same habit. Different framing. Because the framing is what makes it stick.
+
+Alfred supports six professional profiles, each with its own vocabulary, safety rules, and way of explaining every concept:
+
+| Your background | "Save your progress" sounds like | "Try something safely" sounds like |
+|-----------------|----------------------------------|-----------------------------------|
+| Data science | Checkpoint your experiment | Test a new approach without touching your baseline |
+| Research | Sign a lab notebook page | Run a pilot study before the full experiment |
+| Business analytics | Save a version of the spreadsheet | Make a copy of the report before changing it |
+| Product analytics | Log a snapshot of your metrics | Run a test on a small group before rolling out |
+| Data platforms | Take a snapshot before making changes | Test on a copy of the data, not the real thing |
+| General | Save your work | Work on a copy, not the original |
+
+**It teaches eight habits, one at a time** — not all at once, only when you hit a moment where each one matters:
+
+1. **Look before you leap** — Check what state things are in before you start
+2. **Name it before you build it** — Decide what you're doing before you do it
+3. **Save often** — Don't wait until the end to save your work
+4. **Experiment safely** — Try things on a copy, not the original
+5. **One thing at a time** — Change one thing, make sure it works, then move on
+6. **Let the machine handle the cleanup** — Tedious consistency fixes happen automatically
+7. **Know where results came from** — Every output traces back to what produced it
+8. **Teach the system your preferences** — Your corrections become permanent rules
+
+**It protects you from mistakes you don't even know you could make.** From the moment you start, Alfred is quietly running safety checks — preventing you from accidentally saving sensitive information, blocking you from overwriting the main version of your project, keeping your work tidy automatically. You don't have to learn these. They just work.
+
+**It explains less and less over time.** The first time you encounter a habit, you get a full explanation in your field's language. The second and third time, a brief nudge. After that — if you never asked "why?" — Alfred goes silent on that concept. It assumes you've got it and moves on. You can also say "I already know this" at any point to skip ahead.
+
+**What this looks like in practice:**
+
+*Week 1:* You ask the AI to build something. Before it starts, Alfred explains: "Let's check what state the project is in first — like reading your lab notebook before starting today's experiment." You learn why this matters. Alfred saves your work for you at natural stopping points and explains what it's doing each time.
+
+*Week 4:* You ask the AI to build something. Alfred checks the project state silently — no explanation, because you stopped needing one two weeks ago. It still saves your work at stopping points, but no longer narrates it. The safety checks are running, but you don't notice them. You're just building.
+
+The result: you go from "I've never done this" to "I'm building things with an invisible safety net" — without ever being overwhelmed.
+
+---
+
+### If you're an expert: skilled to supercharged
+
+You already have good habits. You don't need anyone explaining the basics.
+
+Alfred knows that too.
+
+**Silent from day one.** When you tell Alfred you're advanced, it skips every explanation. No tutorials, no nudges. You get the automation and the safety net — without the teaching.
+
+**What you actually get: zero cognitive overhead on everything except the work itself.**
+
+- **Automated safety** runs without you thinking about it — dangerous files blocked, work kept tidy on every save, project state summarized at the start of every session
+- **Session memory** — Alfred bookmarks exactly what you were working on when you stop, and picks it up when you come back. No "where was I?" moments
+- **Workflow shortcuts** that turn multi-step operations into single actions — start a new task (with proper isolation), save your work (with safety checks), fix all consistency issues in a loop until everything passes
+- **An environment that learns from you** — and this is the real power. Every time you correct Alfred ("don't do that," "always do it this way"), it saves that preference. Correct it enough times, and you can promote that preference into a permanent rule — or into an automated action that enforces it without you having to remember
+
+**The correction-to-automation pipeline:**
+
+```
+You say "don't do that"  →  Alfred remembers (this session)
+It keeps happening        →  You promote it to a permanent rule (every session)
+You want it enforced      →  It becomes an automated action (runs by itself)
+```
+
+Your feedback literally reshapes your environment. Over time, you're not just using Alfred — you're training it to work the way you work. It learns your preferences, encodes your standards, and automates your blind spots away.
+
+**What this means in practice:** Every minute you used to spend on operational overhead — remembering where you left off, formatting, double-checking safety, repeating the same corrections — is now handled. Your full cognitive capacity goes to the actual problem. You think, Alfred handles everything else.
+
+The result: you're not a person using a tool. You're a person whose entire working environment has been shaped by your own feedback into a system that anticipates, protects, and accelerates — silently.
+
+---
+
+## What makes this different
+
+Plenty of tools do pieces of this. Tutorials exist. Automated safety checks exist. Personalization exists. But nothing combines all three — and nothing is designed to make itself unnecessary.
+
+- **Teaching that tracks understanding and withdraws automatically.** Most onboarding either explains forever or explains once. Alfred tracks each habit individually, monitors whether you're still asking questions, and fades when you stop needing it — per concept, not globally.
+
+- **Professional vocabulary matched to your world.** Not generic "plain English" — structured translations for six professional domains, each with its own analogies, safety rules, warnings, and ways of interpreting errors. The same underlying habit, expressed in six different professional languages.
+
+- **A feedback loop that turns your corrections into your environment.** Most tools let you set preferences in a menu. Alfred lets your natural, in-the-moment corrections ("no, don't do that") gradually harden into permanent rules and then into automated actions — so the same mistake literally cannot happen again.
+
+Most onboarding is designed to stay visible — it's a feature. Alfred is designed to disappear.
+
+## The behavioral science
+
+Three established principles, applied to a new domain:
+
+**Scaffolding that withdraws** (fading support). Alfred provides strong guidance when you're learning and withdraws it as you demonstrate competence. Critically, it tracks this per individual habit, not globally — you can be an expert on saving your work and still need guidance on tracking where results came from. This is more granular than most fading systems, which operate at the level of the whole learner.
+
+**Analogical transfer for habit formation** (connecting new behaviors to existing knowledge). Rather than teaching abstract concepts and hoping they stick, Alfred maps every habit onto a concrete practice the learner already does in their professional life. "Save your work frequently" becomes "checkpoint your experiment" or "sign your lab notebook" — not a new idea to learn, but an existing mental model to extend. This exploits the fact that behaviors anchored to existing routines are far more likely to persist than behaviors taught in isolation.
+
+**Choice architecture through progressive environmental design** (reshaping the environment so correct behavior is the default). Alfred doesn't just teach you what to do — it automates the behaviors you shouldn't have to think about, blocks common mistakes before they happen, and lets your own corrections gradually reshape the rules and automation around you. Over time, the environment itself makes good habits the path of least resistance. You're not choosing to follow best practices — you're working in a system where best practices are the default and violations require effort.
+
+The goal state: a learner who has internalized the habits, working inside an environment shaped by their own feedback, with Alfred doing nothing visible at all. Teaching has faded. Automation handles the mechanics. Corrections have become constraints.
+
+The measure of success is absence.


### PR DESCRIPTION
## Summary
- Adds `docs/PITCH.md` — a jargon-free explainer of what Alfred is and why it matters
- Two narratives: beginner (0→1) and expert (skilled→supercharged)
- Includes before/after vignettes, corrected behavioral science terminology (analogical transfer, choice architecture, fading), persona translation table, and the correction-to-automation pipeline
- Written for a non-technical audience (e.g., behavioral scientist) but useful as a general pitch

## Test plan
- [ ] Read as a non-coder — no unexplained jargon
- [ ] Persona table examples are accessible (no "sweep in isolation" or "staging environment")
- [ ] `scripts/smoke-test.sh` passes

https://claude.ai/code/session_01BDSpthh5resJhUkiyDusnk