### PR TITLE
Add /vet slash command for plan pressure-testing

### DIFF
--- a/.claude/commands/vet.md
+++ b/.claude/commands/vet.md
@@ -1,0 +1,85 @@
+# Vet This Plan
+
+Pressure-test the current plan, proposal, or implementation strategy before committing to it.
+
+## Process
+
+Work through each step methodically. Use tools to verify — don't just reason from memory.
+
+### 1. Extract claims, assumptions, and decisions
+
+Read the plan (from conversation context, plan mode, or the user's description) and list:
+- **Claims**: statements of fact ("this file exports X", "the API returns Y")
+- **Assumptions**: things taken as true but not yet verified ("this won't break Z", "the existing tests cover this")
+- **Decisions**: choices made ("use approach A instead of B", "put this in file X")
+
+### 2. Verify claims against actual code
+
+For each claim, use Read/Grep/Glob to check it against the codebase. Report:
+- ✅ Verified — matches reality
+- ❌ Wrong — actual state differs (explain how)
+- ⚠️ Unverifiable — can't confirm from code alone
+
+### 3. Challenge each decision
+
+For each decision in the plan:
+- What's the alternative that was implicitly rejected?
+- Is there a reason the alternative is actually better?
+- What's the cost of being wrong about this choice?
+
+### 4. Find what's missing
+
+- What failure modes aren't addressed?
+- What edge cases are ignored?
+- Are there dependencies or ordering constraints not mentioned?
+- What would break if the plan's assumptions are wrong?
+- For academic work: are there statistical validity concerns, reproducibility gaps, or missing controls?
+
+### 5. Skeptical reviewer pass
+
+Ask: "If a careful reviewer (or a thesis committee member) read this plan, what would they push back on?" List the top 3 objections.
+
+### 6. Revise
+
+Produce a revised plan that:
+- Fixes any wrong claims
+- Addresses the strongest objections
+- Makes remaining uncertainties explicit (marked with ⚠️)
+- Preserves what was already solid
+
+### 7. Verdict
+
+End with one of:
+- **Ready** — plan is solid, proceed with confidence
+- **Ready with caveats** — proceed, but watch the flagged items
+- **Needs rework** — specific issues must be resolved first
+
+## Output format
+
+```
+## Vet Report
+
+### Claims & Assumptions
+| # | Statement | Type | Status |
+|---|-----------|------|--------|
+| 1 | ...       | Claim | ✅/❌/⚠️ |
+
+### Decisions Challenged
+- **Decision**: ...
+  - Alternative: ...
+  - Risk if wrong: ...
+
+### Missing / Failure Modes
+- ...
+
+### Skeptical Reviewer Objections
+1. ...
+2. ...
+3. ...
+
+### Revised Plan
+(updated plan here)
+
+### Verdict: Ready / Ready with caveats / Needs rework
+(summary)
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Key concern: rigor, reproducibility, citation accuracy, IRB compliance.
 2. **Keep commits atomic.** One concern per commit, one concern per branch.
 3. **Read before planning.** Verify by reading actual code before proposing any changes.
 4. **Capture corrections immediately.** When redirected ("no", "don't", "stop", "instead"), save a feedback memory before continuing with the corrected approach.
+5. **Vet before committing to plans.** Before calling ExitPlanMode or claiming a plan is complete, run the /vet checklist: verify assumptions against actual code, identify missing failure modes, and flag remaining uncertainties. Do not present unvetted plans as ready.
 
 ## Guardrails
 
@@ -62,6 +63,7 @@ No test/lint commands detected yet. Add them here as your project grows.
 | /health-check | Assess project maturity |
 | /safe-refactor | Test-gated refactoring with rollback |
 | /pr | Branch → commit → push → PR workflow |
+| /vet | Pressure-test a plan before committing to it |
 
 ## Hooks
 
@@ -74,6 +76,16 @@ No test/lint commands detected yet. Add them here as your project grows.
 ## Explain Gate
 
 When you encounter a slash command for a pattern you haven't graduated yet, briefly explain what it does and why before executing. Check `.claude/.onboarding-state.json` for graduation status. Once graduated, execute silently.
+
+## Smart Suggestions
+
+Suggest `/vet` when:
+- About to exit plan mode — always vet first (enforced by Rule #5)
+- About to create a PR from a planned implementation — verify implementation matches the plan
+- A plan has 5+ steps — complexity warrants pressure-testing
+- A plan touches multiple files or systems — cross-cutting risk
+
+Say: *"This plan has some complexity — want me to pressure-test it before we proceed?"*
 
 ## Do NOT
 


### PR DESCRIPTION
Creates .claude/commands/vet.md with a structured 7-step vetting process: extract claims → verify against code → challenge decisions → find gaps → skeptical reviewer pass → revise → verdict.

Updates CLAUDE.md with:
- Non-negotiable rule #5: vet before committing to plans
- /vet entry in slash commands table
- Smart Suggestions section for auto-fire triggers

https://claude.ai/code/session_01SUgsrtmse1Y5pbFm12U8DE