### PR TITLE
docs: synchronize all documentation with current project state

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ From here, you just work. Alfred handles version control, formatting, and safety
 **You write SQL or scripts, but you're not a software engineer.** Alfred adds the engineering practices you're missing — version control, testing, reproducible environments — without making you learn them upfront. It translates each concept into your domain: "saving a version of your spreadsheet" instead of "committing to a branch."
 → [Quick start](#get-started)
 
-**You're an experienced developer.** Skip the teaching. Alfred gives you pre-configured hooks (auto-format, CI gate, drift detection), 11 slash commands, and a self-improving rule system. Point it at a new repo or an existing one — it audits what's there, fills in what's missing, and starts in silent mode. Every correction you make gets captured; repeat it enough and Alfred promotes it into a permanent rule or an automated hook that enforces it without you. Over time, your environment reshapes itself around how you actually work.
+**You're an experienced developer.** Skip the teaching. Alfred gives you pre-configured hooks (auto-format, CI gate, drift detection), 19 slash commands, and a self-improving rule system. Point it at a new repo or an existing one — it audits what's there, fills in what's missing, and starts in silent mode. Every correction you make gets captured; repeat it enough and Alfred promotes it into a permanent rule or an automated hook that enforces it without you. Over time, your environment reshapes itself around how you actually work.
 → [System design docs](docs/AI_ASSISTED_DEV_GUIDE.md)
 
 ---
@@ -52,7 +52,17 @@ Alfred runs on [Claude Code](https://docs.anthropic.com/en/docs/claude-code), An
 **If you've never used Claude Code:**
 Follow the [setup guide](docs/GETTING_STARTED.md) — it walks through everything from installation to your first project, step by step.
 
-**Starting a new project:**
+**Install as a Claude Code plugin** (recommended):
+
+In any Claude Code session:
+```
+/plugin marketplace add DrakeCaraker/alfred
+/plugin install alfred@DrakeCaraker/alfred
+```
+
+Then open your project and type `/bootstrap`. Alfred works in any project.
+
+**Starting a new project** (alternative — clones Alfred as a template):
 
 ```bash
 git clone https://github.com/DrakeCaraker/alfred.git my-project
@@ -73,13 +83,7 @@ claude
 
 Then type `/bootstrap` and answer 3 questions. Alfred audits what's already there, fills in what's missing, and sets up guardrails around your existing work. That's it. Start working.
 
-After `/bootstrap`, three commands cover 90% of daily use:
-
-| Command | When to use it |
-|---------|---------------|
-| `/new-work` | Starting a task — creates a branch, scopes the work |
-| `/commit` | Saving progress — checks for dangerous files first |
-| `/teach` | Curious about a habit — delivers a lesson in your domain's language |
+After `/bootstrap`, three commands cover 90% of daily use: **`/new-work`** (start a task), **`/commit`** (save progress), **`/teach`** (learn a habit).
 
 <details>
 <summary>All commands</summary>
@@ -90,17 +94,18 @@ After `/bootstrap`, three commands cover 90% of daily use:
 | `/github-account-setup` | Connect to GitHub or create an account |
 | `/teach` | Next habit lesson — or `/teach all` for progress, `/teach <name>` to revisit |
 | `/status` | Graduated habits, level, next steps |
-| `/commit` | Safe commit — blocks binaries, warns on large files |
+| `/commit` | Safe commit — runs `make check`, blocks binaries, warns on large files |
 | `/new-work` | Scoped branch with task list |
 | `/ci-fix` | Auto-fix loop: lint, format, typecheck, test until green |
 | `/self-improve` | Promote recurring corrections to permanent rules |
 | `/health-check` | Project maturity assessment (5 levels) |
 | `/safe-refactor` | One change at a time, auto-rollback on test failure |
 | `/experiment-summary` | Inventory results with provenance |
-| `/pr` | Push and open a pull request |
+| `/pr` | Push and open a pull request (runs `make check` first) |
 | `/vet` | Pressure-test a plan before committing to it |
+| `/audit` | Security and quality audit with guided fixes |
 | `/persona` | View or change your active persona |
-| `/collective preview` | Preview collective team corrections |
+| `/collective` | Preview, contribute, or ingest shared learning signals |
 | `/pilot-consent` | View what's collected, opt in or out |
 | `/pilot-report` | Submit feedback (PII-scrubbed) |
 | `/pilot-delete` | Delete your data locally or from the repo |
@@ -154,6 +159,19 @@ The end state: a working environment that was shaped by your own decisions — w
 
 ---
 
+## Developer tools
+
+```bash
+make check    # Full CI-equivalent validation (validate + lint + test)
+make audit    # Security lint (injection, secrets, cleanup traps, sync)
+make fix      # Auto-fix: sync commands + hooks + permissions
+```
+
+Full automation details: [`docs/WORKFLOW_GUIDE.md`](docs/WORKFLOW_GUIDE.md)
+Prompting tips: [`docs/PROMPTING_GUIDE.md`](docs/PROMPTING_GUIDE.md)
+
+---
+
 ## Personas
 
 | # | Persona | Example guardrail |
@@ -182,6 +200,8 @@ One person's discovery becomes everyone's guardrail.
 **Adoption friction is self-correcting.** If anyone finds Alfred too verbose, they say "I know" and it goes silent for that habit. No team-wide configuration needed.
 
 **Measuring adoption**: Opt-in pilot telemetry tracks which habits are graduating and which commands are used — without collecting code, file paths, or PII. Run `scripts/aggregate-pilot.sh` for a team summary. See [`.pilot/README.md`](.pilot/README.md) for the full privacy policy.
+
+**Collective learning**: Corrections from individual users are anonymized, encrypted, and shared as collective signals. When 3+ users hit the same correction, it becomes a recommended team rule. Contributors need zero setup — signals are encrypted with a public key and submitted automatically. Run `/collective ingest` to see what the team is learning.
 
 **Project health**: `/health-check` gives leaders a 5-level maturity snapshot — what's in place, what's missing, what to prioritize.
 

--- a/docs/AI_ASSISTED_DEV_GUIDE.md
+++ b/docs/AI_ASSISTED_DEV_GUIDE.md
@@ -6,11 +6,11 @@ See the [README](../README.md) for quick start and positioning.
 
 ## Overview
 
-Alfred is an AI coding assistant that teaches development habits in your domain's language and turns corrections into permanent rules. It teaches 8 development patterns progressively, adapting to your role and skill level. The system explains itself as you work, then gradually goes silent as you demonstrate understanding.
+Alfred is an AI coding assistant that teaches development habits in your domain's language and turns corrections into permanent rules. It teaches 8 development habits progressively, adapting to your role and skill level. The system explains itself as you work, then gradually goes silent as you demonstrate understanding.
 
-## The 8 Development Patterns
+## The 8 Development Habits
 
-### Pattern 1: Context Before Action
+### Habit 1: Context Before Action
 **Principle**: Know where you are before you move.
 
 Before starting any work, check the state of your project: uncommitted changes, current branch, how far behind main you are, and what happened in your last session. The session-start hook does this automatically.
@@ -18,7 +18,7 @@ Before starting any work, check the state of your project: uncommitted changes, 
 **Auto-mode**: Session-start hook prints status silently.
 **Learn-mode**: "Here's what these numbers mean and why they matter..."
 
-### Pattern 2: Scope Before Work
+### Habit 2: Scope Before Work
 **Principle**: Name what you're doing before you do it.
 
 Define the scope of your work before writing code. Create a branch with a descriptive name, write a task list, and confirm scope before starting. This prevents half-finished sessions and scope creep.
@@ -26,7 +26,7 @@ Define the scope of your work before writing code. Create a branch with a descri
 **Auto-mode**: `/new-work` creates branch + task list without explanation.
 **Learn-mode**: "We're creating a separate workspace so your main project stays safe..."
 
-### Pattern 3: Save Points
+### Habit 3: Save Points
 **Principle**: Checkpoint progress so you can always go back.
 
 Commit frequently with meaningful messages. The `/commit` command adds safety checks (large files, binary artifacts) before each commit. Think of commits as save points in a game — you can always return.
@@ -34,7 +34,7 @@ Commit frequently with meaningful messages. The `/commit` command adds safety ch
 **Auto-mode**: `/commit` runs safety checks and commits silently.
 **Learn-mode**: "This is like saving a version of your document — you can always return to this exact state..."
 
-### Pattern 4: Safe Experimentation
+### Habit 4: Safe Experimentation
 **Principle**: Try things without risk to working code.
 
 Use branches to isolate experiments. If an experiment works, merge it. If not, delete the branch. Your main code is never at risk.
@@ -42,7 +42,7 @@ Use branches to isolate experiments. If an experiment works, merge it. If not, d
 **Auto-mode**: Branch creation and merge/discard without explanation.
 **Learn-mode**: "Think of this as running a side experiment. If it works, we keep it. If not, we throw it away..."
 
-### Pattern 5: One Change, One Test
+### Habit 5: One Change, One Test
 **Principle**: Change deliberately, verify each step.
 
 Make one change at a time and test after each. If something breaks, you know exactly what caused it. The `/safe-refactor` command enforces this with automatic rollback on test failure.
@@ -50,7 +50,7 @@ Make one change at a time and test after each. If something breaks, you know exa
 **Auto-mode**: `/safe-refactor` applies + tests + rollbacks silently.
 **Learn-mode**: "We're going to make one change at a time and check after each one..."
 
-### Pattern 6: Automated Recovery
+### Habit 6: Automated Recovery
 **Principle**: Let machines fix mechanical errors.
 
 Formatting issues, lint errors, and simple type errors can be fixed automatically. The `/ci-fix` command loops through failures, applying fixes until everything passes.
@@ -58,7 +58,7 @@ Formatting issues, lint errors, and simple type errors can be fixed automaticall
 **Auto-mode**: `/ci-fix` loops until green without explanation.
 **Learn-mode**: "These are formatting and syntax errors — like spell-check. The system can fix them automatically..."
 
-### Pattern 7: Provenance
+### Habit 7: Provenance
 **Principle**: Every result traces to a source.
 
 Every number, figure, and result should trace back to the code, data, and configuration that produced it. The `/experiment-summary` command inventories results and tags them with provenance metadata.
@@ -66,7 +66,7 @@ Every number, figure, and result should trace back to the code, data, and config
 **Auto-mode**: `/experiment-summary` tags outputs silently.
 **Learn-mode**: "Every number in your report needs to trace back to the code and data that produced it..."
 
-### Pattern 8: Self-Improvement
+### Habit 8: Self-Improvement
 **Principle**: The system learns from corrections.
 
 When you correct Claude's approach, that correction is saved as a feedback memory. Over time, recurring corrections are promoted to permanent rules (in CLAUDE.md) or automated guards (hooks). The `/self-improve` command manages this promotion ladder.
@@ -81,7 +81,7 @@ Every automated action passes through an explain gate that decides whether to ex
 ```
 Action triggered
     |
-Has user graduated this pattern? --yes--> AUTO: just do it
+Has user graduated this habit? --yes--> AUTO: just do it
     | no
 Has user seen explanation <3 times? --yes--> LEARN: full explanation
     | no
@@ -92,7 +92,7 @@ BRIEF: one-line reminder + do it
 
 ### Graduation Criteria
 - Seen the explanation 3+ times
-- Didn't ask "why?" in the last 2 occurrences
+- `last_asked_why` is false (asking "why?" resets progress — need 3 more without asking)
 - OR user explicitly says "I know, just do it" (immediate graduation)
 
 ## The Promotion Ladder
@@ -114,7 +114,7 @@ Use `/self-improve` to trigger promotion analysis.
 Alfred ships with 6 personas, each providing:
 - **Domain context** for CLAUDE.md
 - **Guardrails** specific to the domain
-- **Analogy map** translating the 8 patterns into domain language
+- **Analogy map** translating the 8 habits into domain language
 - **Starter artifacts** (directory structure)
 - **Recommended tools** (formatters, linters, etc.)
 - **Work product templates** at 4 complexity levels
@@ -126,7 +126,7 @@ Alfred ships with 6 personas, each providing:
 3. **Business Analytics** — metric accuracy, SQL patterns, stakeholder communication
 4. **Product Analytics** — experiment rigor, funnel analysis, A/B testing
 5. **BI Platform** — data modeling, dbt workflow, pipeline reliability
-6. **General** — language-agnostic software development patterns
+6. **General** — language-agnostic software development habits
 
 ## Customization
 
@@ -142,7 +142,7 @@ Edit the logic in `.claude/commands/teach.md` Step 3. Default is 3 exposures wit
 Delete `.claude/.onboarding-state.json` and run `/bootstrap` again. This resets all graduation progress.
 
 ### Manual Graduation
-Edit `.claude/.onboarding-state.json` directly — set `"graduated": true` for any pattern you want to skip.
+Edit `.claude/.onboarding-state.json` directly — set `"graduated": true` for any habit you want to skip.
 
 ## Hooks Reference
 
@@ -153,15 +153,66 @@ Edit `.claude/.onboarding-state.json` directly — set `"graduated": true` for a
 | session-bookmark.sh | Stop | Save task context for next session |
 | feedback-capture.sh | Stop | Remind to save user corrections |
 | pre-compact.sh | PreCompact | Save critical context before compression |
+| pilot-telemetry.sh | Stop | Record session telemetry + aggregate collective signals |
 | pre-push | git push | Block binaries, large files, and main pushes |
 
 ## State Files
 
 | File | Purpose |
 |------|---------|
-| `.claude/.onboarding-state.json` | Persona, coding level, pattern graduation tracking |
+| `.claude/.onboarding-state.json` | Persona, coding level, habit graduation tracking |
 | `.claude/.session-bookmark.json` | Last session's task, progress, and next steps |
 | `.claude/.session-count` | Session counter for self-improve nudges |
+| `.claude/.pilot-consent.json` | Consent state for telemetry and collective signals |
+| `.claude/.pilot-identity.json` | Anonymous UUID for telemetry |
+| `.claude/.collective-pending.json` | Aggregated signals awaiting push |
+| `.claude/.pilot-session-start` | Session start timestamp for duration bucketing |
+
+## Collective Learning
+
+Alfred's collective learning system lets corrections compound across users:
+
+1. Individual corrections are saved as feedback memories
+2. `/self-improve` promotes recurring corrections to CLAUDE.md rules or hooks
+3. `/collective contribute` anonymizes and encrypts corrections, then submits them
+4. When 3+ users hit the same correction, it becomes a recommended team rule
+
+**Privacy**: Signals are anonymized locally (no code, paths, or identifiers), encrypted with a public RSA key before leaving the machine, and stored in a private repo. Contributors need zero setup beyond `gh auth login`.
+
+**For maintainers**: Set `ALFRED_COLLECTIVE_KEY` to decrypt and review signals via `/collective ingest`.
+
+## Automation Stack
+
+Alfred automates development workflows through 7 layers:
+
+| Layer | Trigger | What it does |
+|-------|---------|-------------|
+| PostToolUse | Every Write/Edit | Auto-format + sync command/hook mirrors |
+| Pre-commit | `git commit` | Block stale mirrors + PII scan |
+| Pre-push | `git push` | Security audit + PII scan |
+| CI | Every PR | Validate + lint + test + audit |
+| CI Auto-fix | CI failure | Claude fixes code automatically |
+| Conflict Resolution | Push to main | Claude resolves merge conflicts |
+| Weekly Scan | Monday 9am UTC | Security audit, opens issue on failure |
+
+```bash
+make check    # Full CI-equivalent validation
+make audit    # Deep security lint
+make fix      # Auto-fix sync + permissions
+```
+
+## Prompting Guide
+
+Each persona includes domain-specific prompting tips (Section 10 in persona files). Core principles:
+
+1. **State what, not how** — describe outcomes, not implementations
+2. **Scope before starting** — state constraints and success criteria upfront
+3. **Ask for alternatives** — "give me 2-3 approaches with trade-offs"
+4. **Use depth signals** — "think carefully" for analysis, "vet this" for pressure-testing, "audit this" for review
+5. **Let corrections compound** — explicit corrections become permanent rules
+
+Full guide: [`PROMPTING_GUIDE.md`](PROMPTING_GUIDE.md)
+Full workflow reference: [`WORKFLOW_GUIDE.md`](WORKFLOW_GUIDE.md)
 
 ## Troubleshooting
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -40,50 +40,56 @@ The version number may differ — any number is fine.
 
 ## Step 3: Install Claude Code
 
-In your terminal, type:
+Claude Code is the AI tool Alfred runs on. Install it once:
+
+**Option A — Direct install (recommended):**
+
+Visit [docs.anthropic.com/en/docs/claude-code](https://docs.anthropic.com/en/docs/claude-code) and follow the installation instructions for your system.
+
+**Option B — Via npm:**
 
 ```
 $ npm install -g @anthropic-ai/claude-code
 ```
 
-`npm` is Node's package installer — it was included when you installed Node.js.
-
 Verify it worked:
 
 ```
 $ claude --version
-1.0.0
 ```
-
-> **Other install options**: Claude Code is also available as a [desktop app and web app](https://docs.anthropic.com/en/docs/claude-code/getting-started). The terminal version is what Alfred uses in its examples, but any version works.
 
 ## Step 4: Get Alfred
 
-**If you have git** (most Mac and Linux systems do):
+**Option A — Install as a plugin (recommended):**
+
+Start Claude Code in any project:
+```
+$ claude
+```
+
+Then inside Claude Code, type:
+```
+/plugin marketplace add DrakeCaraker/alfred
+/plugin install alfred@DrakeCaraker/alfred
+```
+
+That's it — Alfred is now available in all your projects. Skip to Step 6.
+
+**Option B — Clone as a template project:**
+
+If you want to start a brand new project based on Alfred:
 
 ```
 $ git clone https://github.com/DrakeCaraker/alfred.git my-project
 $ cd my-project
-$ git config core.hooksPath .githooks
+$ make setup
 ```
 
-`cd` means "change directory" — it moves you into the folder you just downloaded. The last command activates Alfred's safety checks — they block accidental pushes to the main version of your project and prevent large binary files from being saved.
-
-**If you don't have git** (common on Windows):
-
-1. Go to [github.com/DrakeCaraker/alfred](https://github.com/DrakeCaraker/alfred)
-2. Click the green **Code** button, then **Download ZIP**
-3. Unzip the file and rename the folder to `my-project`
-4. In your terminal, navigate to that folder:
-   ```
-   $ cd path/to/my-project
-   ```
-
-> **Tip**: On Mac, type `cd ` (with a space) then drag the folder from Finder into the terminal window. On Windows, right-click the folder in Explorer and choose "Open in Terminal."
-
-> **What the safety checks do**: Alfred runs several things automatically in the background — formatting your code after every edit, showing project status when you start a session, saving your place when a session ends, and preserving context when conversations get long. You don't need to set these up; they activate when you run `/bootstrap`.
+> `make setup` activates Alfred's safety checks — they block accidental pushes to the main version of your project and prevent large binary files from being saved.
 
 ## Step 5: Start Claude Code
+
+> If you installed via plugin (Option A above), you're already in Claude Code. Skip to Step 6.
 
 Type:
 
@@ -154,5 +160,7 @@ Three things you can try:
 - **Start working** — type what you want to do in plain language, like "create a Python script that reads a CSV file"
 - **Run `/teach`** — learn your first development pattern
 - **Run `/status`** — see your progress
+
+> **Want to level up fast?** Read the [Prompting Guide](PROMPTING_GUIDE.md) for tips on getting the best results from Claude Code in your domain.
 
 See the [README](../README.md) for the full list of commands and how Alfred adapts to you.


### PR DESCRIPTION
## Summary
- Updates README, AI_ASSISTED_DEV_GUIDE, and GETTING_STARTED to reflect the current state of the project after this session's major changes
- Fixes "11 slash commands" → 19, adds plugin install as primary method, adds `/audit` and `/collective` to command tables
- Replaces "patterns" with "habits" throughout the dev guide (Rule #7)
- Adds missing hooks, state files, and new sections (Collective Learning, Automation Stack, Prompting Guide)

## Test plan
- [x] `make check` passes (123 tests)
- [x] `make audit` passes
- [x] Cross-doc consistency: command count matches across README/WORKFLOW_GUIDE, no stale "patterns", plugin install in both README and GETTING_STARTED
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)