### PR TITLE
fix(ux): user-friendly Stop hook messages

### DIFF
--- a/.claude/hooks/feedback-capture.sh
+++ b/.claude/hooks/feedback-capture.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Stop hook: safety net for CLAUDE.md rule #6 (immediate feedback capture)
-# Reminds Claude to check for any uncaptured user corrections before session ends.
-echo '{"systemMessage": "Before ending this session, check if any user corrections from this session still need to be saved as feedback memories (CLAUDE.md rule #6). Only capture genuine approach corrections, not routine requests. Check existing memories first to avoid duplicates."}'
+# Stop hook: safety net for feedback capture
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: checking for improvements to save..." >&2

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# PreCompact hook: reminds Claude to save critical context before compression.
-echo '{"systemMessage": "Context compression starting. Before continuing, save any in-progress task state, critical file paths, current branch, and uncommitted decisions to the plan file or memory so they survive compression."}'
+# PreCompact hook: reminds Claude to save context before compression
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: preserving context before compression..." >&2

--- a/.claude/hooks/session-bookmark.sh
+++ b/.claude/hooks/session-bookmark.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 # Stop hook: prompt Claude to save session context for next-session resume
-echo '{"systemMessage": "Session ending. Save a session bookmark to .claude/.session-bookmark.json with: current task description, progress summary, branch name, files modified, and next steps. Read the existing bookmark first to preserve context. Format as JSON with keys: timestamp, task, progress, branch, files_modified, next_steps."}'
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: saving your session progress..." >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,9 +78,21 @@ make fix      # Auto-fix: sync commands + hooks + permissions
 
 - **Format on write**: auto-formats files after every edit (detects ruff, prettier, gofmt, etc.)
 - **Session start**: shows git status, branch safety, onboarding progress, and session resume
-- **Session bookmark**: saves task context on session end for resume next time
-- **Feedback capture**: reminds to save corrections as memories before session ends
-- **Pre-compact**: saves critical context before conversation compression
+- **Session bookmark**: notifies user that session progress is being saved
+- **Feedback capture**: notifies user that improvements are being checked
+- **Pre-compact**: notifies user that context is being preserved
+
+## Session End Behavior
+
+When a session ends (Stop hooks fire), do these silently — the hooks show user-friendly messages, your job is the actual work:
+
+1. **Save bookmark**: Write `.claude/.session-bookmark.json` with: task description, progress summary, branch name, files modified, and next steps. Read the existing bookmark first. Format as JSON with keys: `timestamp`, `task`, `progress`, `branch`, `files_modified`, `next_steps`.
+
+2. **Capture feedback**: Check if any user corrections from this session need to be saved as feedback memories (Rule #4). Only capture genuine approach corrections, not routine requests. Check existing memories first to avoid duplicates.
+
+## Pre-Compact Behavior
+
+When context compression starts (PreCompact hook fires), save any in-progress task state, critical file paths, current branch, and uncommitted decisions to the plan or memory so they survive compression.
 
 ## Explain Gate
 

--- a/hooks/feedback-capture.sh
+++ b/hooks/feedback-capture.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-# Stop hook: safety net for CLAUDE.md rule #6 (immediate feedback capture)
-# Reminds Claude to check for any uncaptured user corrections before session ends.
-echo '{"systemMessage": "Before ending this session, check if any user corrections from this session still need to be saved as feedback memories (CLAUDE.md rule #6). Only capture genuine approach corrections, not routine requests. Check existing memories first to avoid duplicates."}'
+# Stop hook: safety net for feedback capture
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: checking for improvements to save..." >&2

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# PreCompact hook: reminds Claude to save critical context before compression.
-echo '{"systemMessage": "Context compression starting. Before continuing, save any in-progress task state, critical file paths, current branch, and uncommitted decisions to the plan file or memory so they survive compression."}'
+# PreCompact hook: reminds Claude to save context before compression
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: preserving context before compression..." >&2

--- a/hooks/session-bookmark.sh
+++ b/hooks/session-bookmark.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 # Stop hook: prompt Claude to save session context for next-session resume
-echo '{"systemMessage": "Session ending. Save a session bookmark to .claude/.session-bookmark.json with: current task description, progress summary, branch name, files modified, and next steps. Read the existing bookmark first to preserve context. Format as JSON with keys: timestamp, task, progress, branch, files_modified, next_steps."}'
+# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+echo "Alfred: saving your session progress..." >&2


### PR DESCRIPTION
## Summary
- Stop hooks now show short, friendly messages instead of raw Claude instructions
- Detailed instructions moved to CLAUDE.md where Claude reads them at session start

**Before:** "Save a session bookmark to .claude/.session-bookmark.json with: current task description..."
**After:** "Alfred: saving your session progress..."

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)