### PR TITLE
chore(self-improve): promote security requirements to Rule #8

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,6 +14,7 @@ Key concern: rigor, reproducibility, citation accuracy, IRB compliance.
 5. **Vet before committing to plans.** Before calling ExitPlanMode or claiming a plan is complete, run the /vet checklist: verify assumptions against actual code, identify missing failure modes, and flag remaining uncertainties. Do not present unvetted plans as ready.
 6. **Sync command and hook copies.** After editing `.claude/commands/*.md` or `.claude/hooks/*.sh`, always copy to `commands/` and `hooks/` respectively — both directories must match. CI will reject mismatches. Run `make fix` to sync automatically.
 7. **Check all output touchpoints after terminology changes.** When renaming user-facing terms, grep `.sh` files, command `.md` templates, and generated file templates. Shell hooks are the highest-frequency touchpoint and easiest to miss.
+8. **Ask security requirements before building data transport.** Before building any feature that stores, moves, or exposes data externally, ask: "Who should have access? Does this need encryption?" Skipping this wastes work when requirements surface later.
 
 ## Guardrails
 


### PR DESCRIPTION
## Summary
- Promote security-requirements-first feedback to CLAUDE.md Rule #8
- Delete 2 stale feedback memories (vocabulary-coherence duplicates Rule #7, layered-automation overridden by shipped design)

## Self-improve report
- Rules: 8 (was 7)
- Feedback memories: 3 remaining (was 5)
- Session counter: reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)