### PR TITLE
fix(ci): pin ruff lint rules and show install errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,12 +25,12 @@ jobs:
 
       - name: Lint shell scripts (shellcheck)
         run: |
-          sudo apt-get -qq install -y shellcheck > /dev/null 2>&1
+          sudo apt-get -qq install -y shellcheck
           shellcheck -S warning .claude/hooks/*.sh .githooks/pre-push .githooks/pre-commit scripts/*.sh
 
       - name: Lint Python code (ruff)
         run: |
-          pip install ruff > /dev/null 2>&1
+          pip install -q ruff
           ruff check collective/
 
       - name: Make scripts executable

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.ruff]
+target-version = "py311"
+
+[tool.ruff.lint]
+# Match ruff defaults: E4xx, E7xx, E9xx, F (no line-length E501)
+select = ["E4", "E7", "E9", "F", "W"]


### PR DESCRIPTION
The CI failure at run #57 (commit e803f07) was caused by ruff lint
errors (E741, E401, F841) in collective/aggregator.py. Those were
fixed in subsequent commits but CI lacked explicit ruff configuration.

- Add pyproject.toml with explicit ruff rule selection (E4/E7/E9/F/W)
  to prevent surprise failures from new ruff versions
- Stop suppressing pip/apt-get install errors in CI so failures are
  visible in logs

https://claude.ai/code/session_01WNCHxRWVZEEwbRF5sdUFoV