### PR TITLE
feat: add Session End and Pre-Compact specs to bootstrap template

### DIFF
--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -215,6 +215,26 @@ Write a new CLAUDE.md file with this structure. Adapt content from the persona f
 - **Feedback capture**: reminds to save corrections as memories before session ends
 - **Pre-compact**: saves critical context before conversation compression
 
+## Session End Behavior
+
+When a session ends (Stop hooks fire), do these silently — the hooks show user-friendly messages, your job is the actual work:
+
+1. **Save bookmark**: Write `.claude/.session-bookmark.json` with: task description, progress summary, branch name, files modified, and next steps. Read the existing bookmark first. Format as JSON with keys: `timestamp`, `task`, `progress`, `branch`, `files_modified`, `next_steps`.
+
+2. **Capture feedback**: Check if any user corrections from this session need to be saved as feedback memories (Rule #4). Only capture genuine approach corrections, not routine requests. Check existing memories first to avoid duplicates.
+
+## Pre-Compact Behavior
+
+When context compression starts (PreCompact hook fires):
+
+1. **Update bookmark**: Write `.claude/.session-bookmark.json` with current task state (same format as session-end). Add `"checkpoint": "pre-compact"` to distinguish from session-end bookmarks.
+
+2. **Safety-net feedback scan**: Check if any user corrections from this session haven't been saved as feedback memories yet (Rule #4 safety net).
+
+3. **Save uncommitted decisions**: If you made design decisions during this session that aren't captured in code, commits, or memories, write them to memory now — the reasoning will not survive compression.
+
+Do this quickly and silently. Do not suggest commands or ask questions.
+
 ## Explain Gate
 
 When you encounter a slash command for a habit you haven't graduated yet, briefly explain what it does and why before executing. Check `.claude/.onboarding-state.json` for graduation status. Once graduated, execute silently.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,15 @@ When a session ends (Stop hooks fire), do these silently — the hooks show user
 
 ## Pre-Compact Behavior
 
-When context compression starts (PreCompact hook fires), save any in-progress task state, critical file paths, current branch, and uncommitted decisions to the plan or memory so they survive compression.
+When context compression starts (PreCompact hook fires):
+
+1. **Update bookmark**: Write `.claude/.session-bookmark.json` with current task state (same format as session-end). Add `"checkpoint": "pre-compact"` to distinguish from session-end bookmarks.
+
+2. **Safety-net feedback scan**: Check if any user corrections from this session haven't been saved as feedback memories yet (Rule #4 safety net).
+
+3. **Save uncommitted decisions**: If you made design decisions during this session that aren't captured in code, commits, or memories, write them to memory now — the reasoning will not survive compression.
+
+Do this quickly and silently. Do not suggest commands or ask questions.
 
 ## Explain Gate
 

--- a/commands/bootstrap.md
+++ b/commands/bootstrap.md
@@ -215,6 +215,26 @@ Write a new CLAUDE.md file with this structure. Adapt content from the persona f
 - **Feedback capture**: reminds to save corrections as memories before session ends
 - **Pre-compact**: saves critical context before conversation compression
 
+## Session End Behavior
+
+When a session ends (Stop hooks fire), do these silently — the hooks show user-friendly messages, your job is the actual work:
+
+1. **Save bookmark**: Write `.claude/.session-bookmark.json` with: task description, progress summary, branch name, files modified, and next steps. Read the existing bookmark first. Format as JSON with keys: `timestamp`, `task`, `progress`, `branch`, `files_modified`, `next_steps`.
+
+2. **Capture feedback**: Check if any user corrections from this session need to be saved as feedback memories (Rule #4). Only capture genuine approach corrections, not routine requests. Check existing memories first to avoid duplicates.
+
+## Pre-Compact Behavior
+
+When context compression starts (PreCompact hook fires):
+
+1. **Update bookmark**: Write `.claude/.session-bookmark.json` with current task state (same format as session-end). Add `"checkpoint": "pre-compact"` to distinguish from session-end bookmarks.
+
+2. **Safety-net feedback scan**: Check if any user corrections from this session haven't been saved as feedback memories yet (Rule #4 safety net).
+
+3. **Save uncommitted decisions**: If you made design decisions during this session that aren't captured in code, commits, or memories, write them to memory now — the reasoning will not survive compression.
+
+Do this quickly and silently. Do not suggest commands or ask questions.
+
 ## Explain Gate
 
 When you encounter a slash command for a habit you haven't graduated yet, briefly explain what it does and why before executing. Check `.claude/.onboarding-state.json` for graduation status. Once graduated, execute silently.


### PR DESCRIPTION
## Summary
- Bootstrap template now generates Session End Behavior and Pre-Compact Behavior sections in every user's CLAUDE.md — previously hooks fired but Claude had no instructions on what to do
- Pre-Compact upgraded from a single vague sentence to a structured 3-step checklist: checkpoint bookmark, safety-net feedback scan, save uncommitted decisions
- This project's own CLAUDE.md updated to match

## Context
Discovered during vet review: the bootstrap template (Step 4) generates CLAUDE.md ending at "Do NOT" — the Session End and Pre-Compact specs only existed in Alfred's own CLAUDE.md, not in any user-facing output. Every bootstrapped project had hooks registered in settings.json that fired messages like "Alfred: preserving context..." but no CLAUDE.md instructions telling Claude what to preserve or where.

## Test plan
- [x] `make check` passes (128 checks)
- [x] `make audit` passes
- [x] Command mirror in sync
- [ ] CI passes
- [ ] Phase 2 validation: test correction capture + pre-compact in dash-shap

🤖 Generated with [Claude Code](https://claude.com/claude-code)