### PR TITLE
docs: business review — reframe strategy around validation and platfo…

### DIFF
--- a/docs/internal/BUSINESS_PLAN.md
+++ b/docs/internal/BUSINESS_PLAN.md
@@ -1,6 +1,6 @@
 # Alfred Business Plan
 
-*Internal document. Updated 2026-03-28.*
+*Internal document. Updated 2026-03-30.*
 
 ## Product
 
@@ -57,20 +57,29 @@ Open-core with team tier (proven model: GitLab, Sentry, PostHog).
 | Tier | Price | Features |
 |------|-------|----------|
 | Free | $0 | All commands, personas, habits, self-improvement, collective contribution |
-| Team | $10/user/month | Collective dashboard, team analytics, admin controls, priority support |
+| Team | $10/user/month | CLAUDE.md governance (admin-controlled, auditable, rollback-able), team-wide correction patterns ("8 of 10 hit the same mistake"), onboarding acceleration (new hires inherit accumulated guardrails), priority support |
 | Enterprise | $30/user/month | SSO, custom personas, private collective, compliance reporting |
 
-Free tier builds community. Team tier monetizes collective learning. Enterprise tier is real revenue.
+Free tier builds community. Team tier monetizes governance, onboarding speed, and collective intelligence — things engineering managers already buy. Enterprise tier is real revenue.
 
-## Revenue Projections (conservative)
+**Team tier value prop must map to existing manager concerns:**
+- Code quality → "systematic mistakes prevented" (not "habits graduated")
+- Onboarding speed → "new hire inherits team's accumulated corrections as guardrails"
+- Consistency → "CLAUDE.md governance: one admin controls what every team member gets"
 
-| Year | Free users | Paid teams | Revenue |
-|------|-----------|-----------|---------|
-| 2026 (H2) | 100-500 | 0 | $0 |
-| 2027 | 1,000-5,000 | 20-50 | $50K-150K |
-| 2028 | 5,000-20,000 | 100-300 | $300K-1M |
+Do NOT pitch habit analytics. Pitch governance, quality, and onboarding.
 
-Projections assume product-market fit is validated by end of 2026.
+## Validation Milestones (revenue projections deferred until PMF confirmed)
+
+No dollar figures until paying design partners exist. Revenue projections based on zero data points create false confidence.
+
+| Year | Goal | Success metric |
+|------|------|----------------|
+| 2026 (H2) | Validate product-market fit | 10+ returning users (3+ sessions each) |
+| 2027 | Test willingness-to-pay | 3 teams running paid pilots |
+| 2028 | Build paid tier (if WTP confirmed) | First paying customers |
+
+**Why no revenue projections:** Previous projections ($50K-150K in 2027 from 20-50 teams) required 21-25 users per team — all using Claude Code, all paying $10/month for habit analytics. That math doesn't work for a plugin on someone else's platform. Revisit projections only after 3+ teams express willingness to pay.
 
 ## Competitive Moat
 
@@ -89,12 +98,16 @@ Projections assume product-market fit is validated by end of 2026.
 
 ## Risks
 
-| Risk | Mitigation |
-|------|-----------|
-| Platform risk (Anthropic builds it in) | Cross-tool support as insurance; behavioral science is platform-independent |
-| No product-market fit | Phase 1-2 designed to test cheaply; pivot if 0 users after distribution |
-| Solo founder scaling | AI-assisted development is the force multiplier; Alfred helps build Alfred |
-| claude-reflect catches up | Network effects from collective learning; deeper behavioral science |
+| Risk | Severity | Mitigation |
+|------|----------|-----------|
+| **Platform risk (Anthropic builds it in)** | **Existential** | Cross-tool support is Phase 2, not deferred. Cursor `.cursorrules`, Copilot `copilot-instructions.md`, Windsurf `.windsurfrules` exports expand TAM 10x and de-risk Anthropic dependency. Behavioral science is tool-agnostic. |
+| "Designed to disappear" = anti-retention | High | After graduation, Alfred shifts from teacher to ongoing quality enforcer. Expand habit library with domain-specific advanced habits. Make collective learning the continuous value. |
+| No product-market fit | High | Phase 1-2 designed to test cheaply; pivot if 0 users after distribution |
+| Academic wedge = low revenue | Medium | Academics validate adoption, not revenue. Revenue comes from data professionals and enterprise (segments 2-3). Don't over-invest in academic-specific features. |
+| Solo founder scaling | Medium | AI-assisted development is the force multiplier; Alfred helps build Alfred |
+| claude-reflect catches up | Medium | Network effects from collective learning; deeper behavioral science |
+
+**Platform risk is the #1 threat.** Every platform eventually absorbs its most popular plugin patterns. Anthropic's roadmap likely includes native memory/corrections, user profiles, progressive onboarding, and team config management. Cross-tool support is the insurance policy — and it must ship before Anthropic absorbs any of these.
 
 ## Go/No-Go Decision Points
 
@@ -118,3 +131,15 @@ Don't build a business yet. Build a community. The most expensive mistake in dev
 | CodeRabbit | Freemium | ~$5M | Free for OSS → pro tier |
 
 All started free, built community, then monetized team/enterprise features. None tried to charge before having users.
+
+**Important caveat:** These are all platforms that own their stack. Alfred is a plugin on someone else's platform. A plugin's revenue ceiling is fundamentally lower unless it becomes cross-platform.
+
+## Alternative Exit Paths
+
+Alfred's best outcome may not be an independent $1M ARR business. Consider:
+
+1. **Acqui-hire / feature acquisition** — Anthropic acquires the approach. Alfred becomes Claude Code's native onboarding system. Behavioral science, personas, and graduation tracking become platform features.
+2. **Feature licensing** — other AI coding tools (Cursor, Windsurf, Copilot) license the persona and teaching system for their own onboarding.
+3. **Consulting/training** — use Alfred as a demonstration of AI-assisted development coaching, sell expertise to enterprises directly.
+
+Build toward optionality, not a single path.

--- a/docs/internal/BUSINESS_REVIEW.md
+++ b/docs/internal/BUSINESS_REVIEW.md
@@ -1,0 +1,87 @@
+# Alfred Business Review — Entrepreneur's Assessment
+
+*Review date: 2026-03-30. Internal document.*
+
+This is an honest, experienced-entrepreneur review of Alfred as a business/product. Alfred is a Claude Code plugin that teaches AI-assisted development habits progressively, adapts to 6 professional domains, and compounds user corrections into team-wide automation. Currently at v0.2.2 with 0 real users, 192 tests, and a solo founder.
+
+Strategy documents reviewed: `BUSINESS_PLAN.md`, `ROADMAP.md`, `COMPETITIVE_LANDSCAPE.md`, `PITCH.md`, `WHO_ITS_FOR.md`, `README.md`.
+
+---
+
+## What's Genuinely Good
+
+### 1. The core insight is real
+"People fail at AI-assisted development because of missing habits, not missing AI capabilities." AI coding tools amplify capability without enforcing discipline. There's a real gap.
+
+### 2. The behavioral science is differentiated
+Scaffolding that fades, analogical transfer, choice architecture — this isn't hand-waving. Per-habit graduation tracking (not global) is more sophisticated than any competitor. Academic citations back the approach.
+
+### 3. The competitive analysis is honest and thorough
+22 competitors mapped, with clear-eyed assessment of what each does better. Identifying claude-reflect as the real threat (not SuperClaude) shows good judgment.
+
+### 4. Execution quality is high for a solo project
+192 tests, 7-layer privacy stack, 6 deep personas (full domain translations, not templates), 19 commands, encrypted collective learning. Over-engineered for pre-market, but the craft is real.
+
+### 5. The go/no-go framework shows discipline
+Explicit decision points (50 installs → proceed, 5 users → build dashboard, 500 users → monetize) prevent premature scaling. "Don't build a business yet. Build a community." is the right instinct.
+
+---
+
+## Critical Problems
+
+### Problem 1: Platform risk is existential
+
+Alfred is 100% dependent on Claude Code. Anthropic's roadmap almost certainly includes native memory/corrections, user profiles, progressive onboarding, and team config management. When (not if) any ship, Alfred's value narrows dramatically. Every platform eventually absorbs its most popular plugin patterns.
+
+**Verdict:** Fragile as a standalone business. Viable as a product. Cross-tool support is insurance — must ship in Phase 2, not "deferred."
+
+### Problem 2: The TAM is tiny
+
+Claude Code users × want progressive teaching × willing to install plugin × teams willing to pay $10/user/month. Each filter cuts dramatically. Previous revenue projections ($50K-150K from 20-50 teams) required 21-25 users per team — aggressive for a plugin. Comparable companies (GitLab, Sentry, Tabnine) own their stack; plugins have fundamentally lower ceilings.
+
+### Problem 3: "Designed to disappear" is anti-retention
+
+"The measure of success is absence." Beautiful UX, terrible business. After graduation: automation is static config files, collective learning slows (fewer corrections from graduated users). The product optimizes for its own obsolescence.
+
+### Problem 4: The team tier value prop was weak
+
+"Analytics on habit graduation" is not a $10/user/month feature. Engineering managers care about code quality, velocity, incident rates. **Updated in BUSINESS_PLAN.md** to reframe as governance, onboarding acceleration, and collective correction patterns.
+
+### Problem 5: Zero market validation
+
+0 users, 0 evidence progressive teaching is wanted, 0 evidence personas matter, 0 evidence collective learning is compelling. A lot of infrastructure for an unvalidated hypothesis.
+
+### Problem 6: Academic wedge = low revenue
+
+Academics validate adoption, not revenue. Graduate students have zero tool budgets. PIs rarely approve per-seat SaaS.
+
+---
+
+## Recommendations Applied
+
+All recommendations have been implemented in `BUSINESS_PLAN.md` and `ROADMAP.md`:
+
+1. **Revenue projections replaced with validation milestones** — no dollar figures until paying design partners exist
+2. **Team tier reframed** — governance, onboarding speed, and correction patterns (not habit analytics)
+3. **Cross-tool export moved to Phase 2** — Cursor `.cursorrules`, Copilot export as a 1-day spike
+4. **Platform risk elevated to existential** — with explicit Anthropic feature watch list
+5. **PMF signals specified** — bootstrap completion rate, session 2 return, voluntary `/teach`, organic WOM
+6. **Alternative exit paths documented** — acqui-hire, feature licensing, consulting
+7. **Retention problem acknowledged** — advanced habit library and continuous collective value as mitigations
+
+---
+
+## Bottom Line
+
+**Is Alfred a legitimate product?** Yes. Real problem, thoughtful approach, genuine behavioral science, high execution quality.
+
+**Is Alfred a legitimate business?** Not yet. The path is narrow: platform risk is existential, TAM is small, monetization mechanics need work, "designed to disappear" fights retention, and there's zero validation.
+
+**What it is right now:** A well-crafted portfolio piece and an intellectual contribution to how AI-assisted development should work. The ideas are worth more than the code.
+
+**What it could become:**
+1. A validated product with a small but loyal community (most likely)
+2. A feature acquired by Anthropic or another AI coding tool (possible, valuable)
+3. An independent business reaching $1M ARR (requires everything to go right + cross-tool + tier redesign)
+
+**The single most important thing:** Stop building infrastructure. Get 5 real users. Everything else is speculation.

--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -1,6 +1,6 @@
 # Alfred Roadmap
 
-*Internal planning document. Updated 2026-03-28.*
+*Internal planning document. Updated 2026-03-30.*
 
 ## Current State
 
@@ -25,9 +25,9 @@ Priority: Prove Alfred works as a plugin before any distribution.
 
 **Exit criteria:** Alfred works end-to-end as a plugin in a real project with zero manual workarounds.
 
-## Phase 2: Distribute (Target: 2026-04-11)
+## Phase 2: Distribute + Cross-Tool Foundation (Target: 2026-04-11)
 
-Priority: Get Alfred in front of people who want it.
+Priority: Get Alfred in front of people who want it. Start de-risking platform dependency.
 
 - [ ] Submit to official Claude Code plugin marketplace (claude.ai/settings/plugins/submit)
   - ⚠️ Verify URL works and understand acceptance criteria
@@ -37,18 +37,28 @@ Priority: Get Alfred in front of people who want it.
 - [ ] Share in relevant communities (Claude Code Discord, data science Slack)
 - [ ] Add CHANGELOG.md link to README
 - [ ] Add docs/WHO_ITS_FOR.md link to README
+- [ ] Build cross-tool config export: Cursor `.cursorrules`, Copilot `copilot-instructions.md` (1-day spike)
+  - This is a config export problem, not a full port — Alfred's behavioral science is tool-agnostic
+  - Expands TAM beyond Claude Code users; de-risks Anthropic platform dependency
+- [ ] Post in r/ClaudeAI, HN ("Show HN"), Claude Code Discord for cold-start validation
 
-**Exit criteria:** Alfred discoverable by people actively looking for Claude Code plugins.
+**Exit criteria:** Alfred discoverable by people actively looking for Claude Code plugins. Cross-tool export prototype exists.
 
 ## Phase 3: First Users (Target: 2026-04-25)
 
-Priority: Get 5 real users and learn from them.
+Priority: Get 5 real users and learn from them. **This is the only phase that matters — everything else is speculation until strangers use it and come back.**
 
 - [ ] Monitor collective signal submissions (GitHub issues on DrakeCaraker/alfred)
 - [ ] Track: which personas are chosen, which habits graduate first, which commands are used
 - [ ] Respond to any GitHub issues within 24 hours
 - [ ] Run `/self-improve` weekly to capture emerging patterns
 - [ ] Collect qualitative feedback (DM anyone who installs)
+- [ ] Measure these PMF signals specifically:
+  - Bootstrap completion rate (do they finish setup?)
+  - Session 2 return rate (do they come back?)
+  - Voluntary `/teach` usage (do they seek learning?)
+  - Organic word-of-mouth (do they tell anyone?)
+- [ ] If 0 of these signals after 50 installs → the hypothesis is wrong. Pivot or stop.
 
 **Exit criteria:** 5 users have completed `/bootstrap` and used Alfred for 3+ sessions.
 
@@ -66,17 +76,18 @@ Priority: Respond to real usage data.
 
 ## Deferred (No timeline)
 
-- Cross-tool config adapter (Cursor, Copilot, etc.)
 - Correction confidence scoring (0.60-0.95 scale like claude-reflect)
 - Additional personas (security engineering, mobile dev, DevOps)
-- Team analytics dashboard
+- Team analytics dashboard — reframed as governance + onboarding speed (not habit graduation)
 - Marketing website
+- Advanced habit library (domain-specific habits beyond the core 8, for post-graduation retention)
 
 ## Competitive Watch
 
 - **claude-reflect** (861 stars): If they add teaching or personas, Alfred's differentiation narrows. Alfred's defense: collective learning (network effects).
 - **learn-faster-kit** (139 stars): General learning tool, already in awesome-claude-code. Alfred's differentiation: development habits specifically + 6 professional personas.
 - **SuperClaude** (22K stars): Power-user tool, different audience. Don't compete.
+- **Anthropic native features**: The existential threat. Watch for: native memory/corrections, user profiles, progressive onboarding, team config management. Any of these shipping natively narrows Alfred's value prop. Cross-tool export is the hedge.
 
 ## Key Metrics (once users exist)
 


### PR DESCRIPTION
…rm risk

Entrepreneur assessment of Alfred's business viability. Key changes:
- Replace revenue projections with validation milestones (no $ until PMF)
- Elevate platform risk to existential; move cross-tool export to Phase 2
- Reframe team tier as governance/onboarding/quality (not habit analytics)
- Add alternative exit paths (acqui-hire, licensing, consulting)
- Add PMF signal tracking to Phase 3 with explicit kill criteria
- Save full business review as docs/internal/BUSINESS_REVIEW.md

https://claude.ai/code/session_01KUTH6v44JUBZss56xh1XPn