### PR TITLE
chore: bump version to 0.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "alfred",
   "description": "AI coding assistant that teaches development habits in your domain's language, then turns your corrections into permanent rules and automated guards.",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "author": {
     "name": "Drake Caraker",
     "email": "drake.caraker@ouraring.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "0.2.2",
+  "version": "0.3.0",
   "description": "AI coding assistant that teaches development habits in your language and turns corrections into permanent rules",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Bump plugin and package version from 0.2.2 to 0.3.0

## What's new in 0.3.0
- Writer/Editor persona (#34)
- Session End + Pre-Compact specs in bootstrap template (#35)
- All 19 commands in docs + audit in /pr (#36)
- Shell-level command tracking + disk-based telemetry (#38)

## Test plan
- [x] `make check` passes
- [ ] CI passes
- [ ] dash-shap plugin update picks up 0.3.0