### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "alfred",
   "description": "AI coding assistant that teaches development habits in your domain's language, then turns your corrections into permanent rules and automated guards.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "Drake Caraker",
     "email": "DrakeCaraker@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "AI coding assistant that teaches development habits in your language and turns corrections into permanent rules",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump plugin and package version from 0.3.0 to 0.3.1.

## What's new in 0.3.1
- Telemetry writes directly in shell (#41)
- Dead command tracking hook removed (#40)
- Identity/consent files removed from git, gitignore hardened (#44)
- Aggregator output upgraded to schema v2.0 (#45)
- Ingest gracefully skips undecryptable batches (#42)
- Spike-test hook guardrail promoted (#46)

## Test plan
- [x] `make check` passes
- [ ] CI passes