### PR TITLE
fix: update Directory Map to reflect actual project structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,14 +33,18 @@ Key concern: rigor, reproducibility, citation accuracy, IRB compliance.
 .
 ├── CLAUDE.md
 ├── README.md
-├── docs/
-├── scripts/
-├── data/raw/          (original, unmodified data — read-only)
-├── data/processed/    (cleaned, transformed data)
-├── analysis/          (numbered scripts: 01_clean.py, 02_analyze.py, ...)
-├── paper/             (manuscript source — LaTeX or Markdown)
-├── figures/           (publication-quality figures with provenance)
-└── results/           (analysis outputs, tables, statistics)
+├── Makefile               (check, audit, fix, publish targets)
+├── .claude/commands/      (slash command definitions)
+├── .claude/hooks/         (session-start, format-on-write, telemetry, etc.)
+├── .claude-plugin/        (plugin.json manifest)
+├── collective/            (aggregator, anonymizer, signal schema, keys)
+├── commands/              (mirror of .claude/commands/ — CI enforces sync)
+├── docs/                  (user guides, internal strategy docs)
+├── hooks/                 (mirror of .claude/hooks/)
+├── personas/              (7 persona templates: ml-ds, research, writer, etc.)
+├── scripts/               (audit, PII scanner, smoke test, collective-sync)
+├── skills/                (smart-suggestions, persona-evolve, etc.)
+└── .pilot/                (telemetry data, privacy docs)
 ```
 
 ## Running


### PR DESCRIPTION
## Summary
- Replace stale research-template directories (data/raw/, analysis/, paper/) with Alfred's actual structure (personas/, collective/, commands/, hooks/, scripts/, skills/)
- Found by `/health-check` — CLAUDE.md referenced files that don't exist

## Note on recommendation #3 (CI)
CI already runs validate, shellcheck, ruff, smoke test (including PII/encryption/aggregator unit tests), and audit. No gap to fix.

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)