### PR TITLE
fix: allow collective signal push without ALFRED_COLLECTIVE_KEY

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -277,7 +277,9 @@ for p in order:
 fi
 
 # 10. Push pending collective signals (silent, non-blocking)
-if [ -f ".claude/.collective-pending.json" ] && [ -n "${ALFRED_COLLECTIVE_KEY:-}" ]; then
+# push-pending handles both paths: encrypted direct push (if key set) or
+# RSA-encrypted issue submission (if no key). Don't gate on key here.
+if [ -f ".claude/.collective-pending.json" ]; then
     bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
 fi
 

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -277,7 +277,9 @@ for p in order:
 fi
 
 # 10. Push pending collective signals (silent, non-blocking)
-if [ -f ".claude/.collective-pending.json" ] && [ -n "${ALFRED_COLLECTIVE_KEY:-}" ]; then
+# push-pending handles both paths: encrypted direct push (if key set) or
+# RSA-encrypted issue submission (if no key). Don't gate on key here.
+if [ -f ".claude/.collective-pending.json" ]; then
     bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
 fi
 


### PR DESCRIPTION
## Summary
- Session-start hook required `ALFRED_COLLECTIVE_KEY` to push pending signals, but `push-pending` already handles the no-key case (falls back to RSA issue submission)
- Regular users' collective signals were silently stuck in `.collective-pending.json` forever
- Now session-start calls push-pending whenever pending signals exist, letting the script decide the path

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)