### PR TITLE
feat: fully automatic signal collection after consent

### DIFF
--- a/.claude/hooks/pilot-telemetry.sh
+++ b/.claude/hooks/pilot-telemetry.sh
@@ -138,15 +138,29 @@ with open(tf, "w") as f:
     json.dump(data, f, indent=2)
 PYEOF
 
-# Aggregate collective signals locally (non-blocking)
-active_memory_dir=""
-while IFS= read -r feedback_file; do
-    active_memory_dir=$(dirname "$feedback_file")
-    break
-done < <(find "$HOME/.claude/projects" -name "feedback_*.md" -type f 2>/dev/null | head -1)
+# Aggregate collective signals from current project's feedback memories
+# Use project_key (already computed above) to scope to this project only
+if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+    python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+fi
 
-if [ -n "$active_memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
-    python3 "$ALFRED_ROOT/collective/aggregator.py" "$active_memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+# Push pending signals with 30-minute debounce (Stop fires after every response)
+if [ -f ".claude/.collective-pending.json" ]; then
+    should_push=false
+    push_marker=".claude/.last-signal-push"
+    if [ ! -f "$push_marker" ]; then
+        should_push=true
+    else
+        last_push=$(cat "$push_marker" 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        if [ $((now_epoch - last_push)) -gt 1800 ]; then
+            should_push=true
+        fi
+    fi
+    if [ "$should_push" = true ]; then
+        bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
+        date +%s > "$push_marker"
+    fi
 fi
 
 exit 0

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
-# PreCompact hook: reminds Claude to save context before compression
-# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+# PreCompact hook: preserve context + push signals before compression
 echo "Alfred: preserving context before compression..." >&2
+
+# Detect Alfred root
+ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Check consent before any data operations
+if [ -f ".claude/.pilot-consent.json" ]; then
+    consented=$(python3 -c "import json; print(json.load(open('.claude/.pilot-consent.json')).get('consented', False))" 2>/dev/null)
+    if [ "$consented" = "True" ]; then
+        # Aggregate signals from current project's feedback memories
+        project_key=$(pwd | sed 's|/|-|g; s|^-||')
+        memory_dir="$HOME/.claude/projects/-${project_key}/memory"
+        if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+            python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+        fi
+
+        # Push pending signals (no debounce — pre-compact is rare)
+        if [ -f ".claude/.collective-pending.json" ]; then
+            bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
+            date +%s > .claude/.last-signal-push
+        fi
+    fi
+fi

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -277,7 +277,9 @@ for p in order:
 fi
 
 # 10. Push pending collective signals (silent, non-blocking)
-if [ -f ".claude/.collective-pending.json" ] && [ -n "${ALFRED_COLLECTIVE_KEY:-}" ]; then
+# push-pending handles both paths: encrypted direct push (if key set) or
+# RSA-encrypted issue submission (if no key). Don't gate on key here.
+if [ -f ".claude/.collective-pending.json" ]; then
     bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
 fi
 

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ target/
 .claude/.session-bookmark.json
 .claude/.pilot-session-start
 .claude/.pilot-nudge-count
+.claude/.last-signal-push
 
 # Persona state (local per-user)
 .claude/alfred-persona.yaml

--- a/hooks/pilot-telemetry.sh
+++ b/hooks/pilot-telemetry.sh
@@ -138,15 +138,29 @@ with open(tf, "w") as f:
     json.dump(data, f, indent=2)
 PYEOF
 
-# Aggregate collective signals locally (non-blocking)
-active_memory_dir=""
-while IFS= read -r feedback_file; do
-    active_memory_dir=$(dirname "$feedback_file")
-    break
-done < <(find "$HOME/.claude/projects" -name "feedback_*.md" -type f 2>/dev/null | head -1)
+# Aggregate collective signals from current project's feedback memories
+# Use project_key (already computed above) to scope to this project only
+if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+    python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+fi
 
-if [ -n "$active_memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
-    python3 "$ALFRED_ROOT/collective/aggregator.py" "$active_memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+# Push pending signals with 30-minute debounce (Stop fires after every response)
+if [ -f ".claude/.collective-pending.json" ]; then
+    should_push=false
+    push_marker=".claude/.last-signal-push"
+    if [ ! -f "$push_marker" ]; then
+        should_push=true
+    else
+        last_push=$(cat "$push_marker" 2>/dev/null || echo 0)
+        now_epoch=$(date +%s)
+        if [ $((now_epoch - last_push)) -gt 1800 ]; then
+            should_push=true
+        fi
+    fi
+    if [ "$should_push" = true ]; then
+        bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
+        date +%s > "$push_marker"
+    fi
 fi
 
 exit 0

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
-# PreCompact hook: reminds Claude to save context before compression
-# User-friendly output only — detailed instructions are in CLAUDE.md "Session End" section
+# PreCompact hook: preserve context + push signals before compression
 echo "Alfred: preserving context before compression..." >&2
+
+# Detect Alfred root
+ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+
+# Check consent before any data operations
+if [ -f ".claude/.pilot-consent.json" ]; then
+    consented=$(python3 -c "import json; print(json.load(open('.claude/.pilot-consent.json')).get('consented', False))" 2>/dev/null)
+    if [ "$consented" = "True" ]; then
+        # Aggregate signals from current project's feedback memories
+        project_key=$(pwd | sed 's|/|-|g; s|^-||')
+        memory_dir="$HOME/.claude/projects/-${project_key}/memory"
+        if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+            python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
+        fi
+
+        # Push pending signals (no debounce — pre-compact is rare)
+        if [ -f ".claude/.collective-pending.json" ]; then
+            bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
+            date +%s > .claude/.last-signal-push
+        fi
+    fi
+fi

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -277,7 +277,9 @@ for p in order:
 fi
 
 # 10. Push pending collective signals (silent, non-blocking)
-if [ -f ".claude/.collective-pending.json" ] && [ -n "${ALFRED_COLLECTIVE_KEY:-}" ]; then
+# push-pending handles both paths: encrypted direct push (if key set) or
+# RSA-encrypted issue submission (if no key). Don't gate on key here.
+if [ -f ".claude/.collective-pending.json" ]; then
     bash "$ALFRED_ROOT/scripts/collective-sync.sh" push-pending >/dev/null 2>&1 &
 fi
 


### PR DESCRIPTION
## Summary
After consent, users never need to do anything manually for data to flow:

- **Stop hook**: generates signals from feedback memories + pushes with 30-min debounce
- **Pre-compact**: generates + pushes immediately (rare event)
- **Session start**: pushes leftover pending signals (belt-and-suspenders)

Also fixes:
- Aggregator scoped across ALL projects instead of current project
- Session-start gated push on `ALFRED_COLLECTIVE_KEY` (subsumes PR #49)

## Data flow after this PR
| Step | Trigger | Automatic? |
|------|---------|-----------|
| Consent | Bootstrap | Once (user says yes/no) |
| Telemetry | Stop hook | Fully automatic |
| Signal generation | Stop hook + pre-compact | Fully automatic |
| Signal push | Stop (30m debounce) + pre-compact + session-start | Fully automatic |

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [x] Hook mirrors in sync
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)