### PR TITLE
fix: project key path computation missing dot/underscore conversion

### DIFF
--- a/.claude/hooks/pilot-telemetry.sh
+++ b/.claude/hooks/pilot-telemetry.sh
@@ -69,7 +69,7 @@ today=$(date +%Y-%m-%d)
 telemetry_file=".pilot/telemetry/${uuid}.json"
 
 # Count feedback memory files on disk
-project_key=$(pwd | sed 's|/|-|g; s|^-||')
+project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
 memory_dir="$HOME/.claude/projects/-${project_key}/memory"
 feedback_files_on_disk=$(ls "$memory_dir"/feedback_*.md 2>/dev/null | wc -l | tr -d ' ')
 

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -10,7 +10,7 @@ if [ -f ".claude/.pilot-consent.json" ]; then
     consented=$(python3 -c "import json; print(json.load(open('.claude/.pilot-consent.json')).get('consented', False))" 2>/dev/null)
     if [ "$consented" = "True" ]; then
         # Aggregate signals from current project's feedback memories
-        project_key=$(pwd | sed 's|/|-|g; s|^-||')
+        project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
         memory_dir="$HOME/.claude/projects/-${project_key}/memory"
         if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
             python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -172,7 +172,7 @@ session_count=$((session_count + 1))
 echo "$session_count" > "$count_file"
 
 # Dynamic memory path
-project_key=$(pwd | sed 's|/|-|g; s|^-||')
+project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
 memory_dir="$HOME/.claude/projects/-${project_key}/memory"
 
 # 6. Feedback memory accumulation check

--- a/hooks/pilot-telemetry.sh
+++ b/hooks/pilot-telemetry.sh
@@ -69,7 +69,7 @@ today=$(date +%Y-%m-%d)
 telemetry_file=".pilot/telemetry/${uuid}.json"
 
 # Count feedback memory files on disk
-project_key=$(pwd | sed 's|/|-|g; s|^-||')
+project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
 memory_dir="$HOME/.claude/projects/-${project_key}/memory"
 feedback_files_on_disk=$(ls "$memory_dir"/feedback_*.md 2>/dev/null | wc -l | tr -d ' ')
 

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -10,7 +10,7 @@ if [ -f ".claude/.pilot-consent.json" ]; then
     consented=$(python3 -c "import json; print(json.load(open('.claude/.pilot-consent.json')).get('consented', False))" 2>/dev/null)
     if [ "$consented" = "True" ]; then
         # Aggregate signals from current project's feedback memories
-        project_key=$(pwd | sed 's|/|-|g; s|^-||')
+        project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
         memory_dir="$HOME/.claude/projects/-${project_key}/memory"
         if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
             python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -172,7 +172,7 @@ session_count=$((session_count + 1))
 echo "$session_count" > "$count_file"
 
 # Dynamic memory path
-project_key=$(pwd | sed 's|/|-|g; s|^-||')
+project_key=$(pwd | sed 's|[/._]|-|g; s|^-||')
 memory_dir="$HOME/.claude/projects/-${project_key}/memory"
 
 # 6. Feedback memory accumulation check


### PR DESCRIPTION
## Summary
- Claude Code converts `.` and `_` to `-` in project paths, but our `sed` only converted `/`
- Every hook using `memory_dir` (session-start, telemetry, pre-compact) was computing the wrong path
- Feedback memory counts were always 0, aggregator found no memories, self-improve nudge never fired
- Fix: `sed 's|[/._]|-|g'` in all 3 hooks

## Verified
```
Fixed:  .../projects/-Users-drake-caraker-ds-projects-dash-shap/memory
Actual: .../projects/-Users-drake-caraker-ds-projects-dash-shap/memory
```

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [x] Path computation matches actual directory
- [ ] CI passes
- [ ] Re-validate in dash-shap: signals generated + pushed automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)