### PR TITLE
fix: ALFRED_ROOT detection walks up to marker instead of hardcoded depth

### DIFF
--- a/.claude/hooks/format-on-write.sh
+++ b/.claude/hooks/format-on-write.sh
@@ -23,7 +23,20 @@ case "$f" in
 esac
 
 # Read preferred formatter from alfred.yaml (if configured)
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 preferred=$("$ALFRED_ROOT/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
 
 # If a specific formatter is configured, use it directly

--- a/.claude/hooks/pilot-telemetry.sh
+++ b/.claude/hooks/pilot-telemetry.sh
@@ -23,7 +23,20 @@ if [ -z "$uuid" ]; then
 fi
 
 # Detect Alfred root for script references
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 
 # Calculate duration bucket
 duration_bucket="unknown"

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -3,7 +3,20 @@
 echo "Alfred: preserving context before compression..." >&2
 
 # Detect Alfred root
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 
 # Check consent before any data operations
 if [ -f ".claude/.pilot-consent.json" ]; then

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,7 +5,20 @@
 echo "=== Alfred Session Warm-Up ===" >&2
 
 # Read configured main branch from alfred.yaml (default: main)
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 MAIN_BRANCH=$("$ALFRED_ROOT/scripts/alfred-config.sh" git.main_branch main 2>/dev/null)
 
 # Detect coding level for beginner-friendly output

--- a/hooks/format-on-write.sh
+++ b/hooks/format-on-write.sh
@@ -23,7 +23,20 @@ case "$f" in
 esac
 
 # Read preferred formatter from alfred.yaml (if configured)
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 preferred=$("$ALFRED_ROOT/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
 
 # If a specific formatter is configured, use it directly

--- a/hooks/pilot-telemetry.sh
+++ b/hooks/pilot-telemetry.sh
@@ -23,7 +23,20 @@ if [ -z "$uuid" ]; then
 fi
 
 # Detect Alfred root for script references
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 
 # Calculate duration bucket
 duration_bucket="unknown"

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -3,7 +3,20 @@
 echo "Alfred: preserving context before compression..." >&2
 
 # Detect Alfred root
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 
 # Check consent before any data operations
 if [ -f ".claude/.pilot-consent.json" ]; then

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -5,7 +5,20 @@
 echo "=== Alfred Session Warm-Up ===" >&2
 
 # Read configured main branch from alfred.yaml (default: main)
-ALFRED_ROOT="${CLAUDE_PLUGIN_ROOT:-$(cd "$(dirname "$0")/../.." && pwd)}"
+# Detect Alfred root: walk up from script location until we find the marker
+if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
+    ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
+else
+    _dir="$(cd "$(dirname "$0")" && pwd)"
+    ALFRED_ROOT="$_dir"
+    while [ "$_dir" != "/" ]; do
+        if [ -f "$_dir/collective/signal_schema.yaml" ]; then
+            ALFRED_ROOT="$_dir"
+            break
+        fi
+        _dir="$(dirname "$_dir")"
+    done
+fi
 MAIN_BRANCH=$("$ALFRED_ROOT/scripts/alfred-config.sh" git.main_branch main 2>/dev/null)
 
 # Detect coding level for beginner-friendly output


### PR DESCRIPTION
## Summary
- Hooks assumed 2 levels below repo root (`.claude/hooks/`), but plugin cache has `0.3.0/hooks/` (1 level) — `../../` resolved to the wrong directory
- Aggregator, config reader, and formatter were never found in plugin installations
- Now walks up from script location looking for `collective/signal_schema.yaml` as root marker
- Works from any depth: `.claude/hooks/`, `hooks/`, or plugin cache

## Root cause
This is why signals were never generated in dash-shap despite the aggregator code being correct — `$ALFRED_ROOT/collective/aggregator.py` resolved to a nonexistent path.

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [x] Root detection verified from plugin cache path (finds aggregator)
- [x] Root detection verified from `.claude/hooks/` path (finds aggregator)
- [ ] CI passes
- [ ] Re-validate in dash-shap: signals generated automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)