### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "alfred",
   "description": "AI coding assistant that teaches development habits in your domain's language, then turns your corrections into permanent rules and automated guards.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": {
     "name": "Drake Caraker",
     "email": "DrakeCaraker@users.noreply.github.com"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "alfred",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "AI coding assistant that teaches development habits in your language and turns corrections into permanent rules",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
Bump from 0.3.1 to 0.3.2. See commit message for changelog.

## Test plan
- [x] `make check` passes
- [ ] CI passes