### PR TITLE
docs: sync all docs with current project state

### DIFF
--- a/.claude/commands/persona.md
+++ b/.claude/commands/persona.md
@@ -55,7 +55,7 @@ Analyzes accumulated corrections and suggests the best-fitting persona.
 1. Read `.claude/.onboarding-state.json` for current persona
 2. Read `.claude/alfred-persona.yaml` for custom_rules, preferred_tools, avoided_tools
 3. Read feedback memories (from `~/.claude/projects/<project-key>/memory/feedback_*.md`)
-4. Read ALL 6 persona files from `.claude/personas/`:
+4. Read ALL 7 persona files from `.claude/personas/`:
    - Extract the Guardrails section from each
    - Extract the Domain Context section from each
 5. Score each persona by counting how many of the user's custom rules and corrections OVERLAP with that persona's guardrails and domain signals

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,35 @@
 All notable changes to Alfred are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.3.2] - 2026-03-29
+
+### Added
+- **Writer/Editor persona**: 7th persona for manuscripts, articles, content creation
+- **Session End + Pre-Compact specs** in bootstrap template — every bootstrapped project gets structured behavior specs
+- **All 19 commands** documented in bootstrap Slash Commands table and CLAUDE.md
+- **`make audit` in /pr pre-flight** — every PR gets a security sweep automatically
+- **Automatic signal collection** — after consent, signals generate and push without user action (Stop hook + pre-compact + session-start)
+- **Internal telemetry policy** document (`docs/internal/TELEMETRY_POLICY.md`)
+
+### Fixed
+- **Telemetry writes directly in shell** — Stop hooks fire after responses but Claude never gets a turn to act on systemMessages. Telemetry now writes via Python in the hook itself.
+- **Project key path** converts dots and underscores to dashes (`sed 's|[/._]|-|g'`) — feedback count was always 0
+- **ALFRED_ROOT detection** walks up to `collective/signal_schema.yaml` marker instead of hardcoded `../..` — aggregator wasn't found in plugin cache
+- **Bootstrap generates settings.json** with correct nested hook format and explicit `anonymous_id` key
+- **Signal schema** updated for writer persona
+- **Aggregator output** upgraded to schema v2.0 (adds `type`, `persona`, `schema_version`, `contributed_at`)
+- **Ingest** gracefully skips undecryptable batches (mixed encryption keys)
+- **Sensitive data** removed from git (identity/consent files, work email in plugin.json)
+- **Directory Map** in CLAUDE.md updated to actual project structure
+- **Aspirational time-based commit trigger** replaced with observable edit-volume trigger
+- **Dead PostToolUse:Skill hook** removed (slash commands are CLI directives, not tool calls)
+- **Session-start signal push** no longer gated on `ALFRED_COLLECTIVE_KEY`
+
+### Security
+- Identity and consent files removed from git tracking, added to .gitignore
+- Work email replaced with GitHub noreply address in plugin.json
+- Hardcoded username removed from PII scanner test fixture
+
 ## [0.2.0] - 2026-03-28
 
 ### Added
@@ -11,12 +40,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/).
 - **CI autofix pipeline**: Claude Code automatically fixes CI failures and resolves merge conflicts
 - **Security audit** (`/audit`, `make audit`): Checks for injection, secrets, cleanup traps, sync, doc-code drift
 - **7-layer automation stack**: PostToolUse sync → pre-commit block → pre-push audit → CI → autofix → conflict resolution → weekly scan
-- **Prompting guides**: Domain-specific prompting tips in all 6 personas + standalone `docs/PROMPTING_GUIDE.md`
+- **Prompting guides**: Domain-specific prompting tips in all 7 personas + standalone `docs/PROMPTING_GUIDE.md`
 - **Smart suggestions**: All 19 commands have contextual trigger conditions and explanations
 - **Progressive disclosure**: Prompting tips surface during `/teach` lessons and early sessions
 - **Branch hygiene nudge**: Session-start warns when branch has 10+ commits ahead
 - **Pre-flight checks**: `/commit` and `/pr` run `make check` before any git operations
-- **192 tests**: 126 structural + 7 encryption + 10 aggregator + 12 hook output + 16 anonymizer + 21 PII scanner
+- **128 checks** via `make check` (structural validation + unit tests for encryption, aggregator, anonymizer, PII scanner)
 - **`make fix`**: Auto-syncs commands + hooks + permissions in one command
 - **User-friendly hook messages**: Stop hooks show "Alfred: saving..." not raw instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Key concern: rigor, reproducibility, citation accuracy, IRB compliance.
 ## Running
 
 ```bash
-make check    # Full validation: validate + lint + test (123 checks)
+make check    # Full validation: validate + lint + test (128 checks)
 make audit    # Deep security lint: injection, secrets, traps, sync
 make fix      # Auto-fix: sync commands + hooks + permissions
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Follow the [setup guide](docs/GETTING_STARTED.md) — it walks through everythin
 In any Claude Code session:
 ```
 /plugin marketplace add DrakeCaraker/alfred
-/plugin install alfred@DrakeCaraker/alfred
+/plugin install alfred@alfred-marketplace
 ```
 
 Then open your project and type `/alfred:bootstrap`. Alfred works in any project.

--- a/commands/persona.md
+++ b/commands/persona.md
@@ -55,7 +55,7 @@ Analyzes accumulated corrections and suggests the best-fitting persona.
 1. Read `.claude/.onboarding-state.json` for current persona
 2. Read `.claude/alfred-persona.yaml` for custom_rules, preferred_tools, avoided_tools
 3. Read feedback memories (from `~/.claude/projects/<project-key>/memory/feedback_*.md`)
-4. Read ALL 6 persona files from `.claude/personas/`:
+4. Read ALL 7 persona files from `.claude/personas/`:
    - Extract the Guardrails section from each
    - Extract the Domain Context section from each
 5. Score each persona by counting how many of the user's custom rules and corrections OVERLAP with that persona's guardrails and domain signals

--- a/docs/AI_ASSISTED_DEV_GUIDE.md
+++ b/docs/AI_ASSISTED_DEV_GUIDE.md
@@ -111,7 +111,7 @@ Use `/self-improve` to trigger promotion analysis.
 
 ## Personas
 
-Alfred ships with 6 personas, each providing:
+Alfred ships with 7 personas, each providing:
 - **Domain context** for CLAUDE.md
 - **Guardrails** specific to the domain
 - **Analogy map** translating the 8 habits into domain language

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -70,7 +70,7 @@ $ claude
 Then inside Claude Code, type:
 ```
 /plugin marketplace add DrakeCaraker/alfred
-/plugin install alfred@DrakeCaraker/alfred
+/plugin install alfred@alfred-marketplace
 ```
 
 That's it — Alfred is now available in all your projects. Skip to Step 6.

--- a/docs/WHO_ITS_FOR.md
+++ b/docs/WHO_ITS_FOR.md
@@ -122,7 +122,7 @@ Alfred is per-project but team-aware. Each member runs `/bootstrap` with their o
 
 ```
 /plugin marketplace add DrakeCaraker/alfred
-/plugin install alfred@DrakeCaraker/alfred
+/plugin install alfred@alfred-marketplace
 ```
 
 Then run `/alfred:bootstrap` in any project.

--- a/docs/internal/AWESOME_SUBMISSION.md
+++ b/docs/internal/AWESOME_SUBMISSION.md
@@ -1,12 +1,12 @@
 # awesome-claude-code Submission Draft
 
 ## PR Title
-Add Alfred — progressive habit teaching with 6 professional personas
+Add Alfred — progressive habit teaching with 7 professional personas
 
 ## Description for the list entry
 
 ```
-- [Alfred](https://github.com/DrakeCaraker/alfred) by [Drake Caraker](https://github.com/DrakeCaraker) — A Claude Code plugin that teaches 8 development habits one at a time using domain-specific language from 6 professional personas (ML/DS, Research, Business Analytics, Product Analytics, Data Platform, General). Tracks competence per-habit and stops explaining once you've learned. Your corrections automatically harden into permanent CLAUDE.md rules and then into automated hooks. Ships with encrypted collective learning, a 7-layer automation stack, 19 slash commands, and 192 tests. The goal: an environment shaped by your own feedback where good practices are the default.
+- [Alfred](https://github.com/DrakeCaraker/alfred) by [Drake Caraker](https://github.com/DrakeCaraker) — A Claude Code plugin that teaches 8 development habits one at a time using domain-specific language from 7 professional personas (ML/DS, Research, Business Analytics, Product Analytics, Data Platform, General, Writer/Editor). Tracks competence per-habit and stops explaining once you've learned. Your corrections automatically harden into permanent CLAUDE.md rules and then into automated hooks. Ships with encrypted collective learning, a 7-layer automation stack, 19 slash commands, and 128 checks. The goal: an environment shaped by your own feedback where good practices are the default.
 ```
 
 ## Suggested section
@@ -23,10 +23,10 @@ learn-faster-kit is a general-purpose learning tool (any topic, spaced repetitio
 >
 > **Key features:**
 > - Progressive teaching that fades as you demonstrate competence (per-habit, not global)
-> - 6 professional personas with domain-specific analogies (ML, Research, Business Analytics, Product Analytics, Data Platform, General)
+> - 7 professional personas with domain-specific analogies (ML, Research, Business Analytics, Product Analytics, Data Platform, General, Writer/Editor)
 > - Correction-to-automation pipeline: feedback memory → CLAUDE.md rule → automated hook
 > - Encrypted collective learning across users (zero-config for contributors)
 > - 7-layer automation stack from PostToolUse to weekly security scans
-> - 19 slash commands, 192 tests, installable as a Claude Code plugin
+> - 19 slash commands, 128 checks, installable as a Claude Code plugin
 >
 > Built on scaffolding theory (Zhang 2025), analogical transfer, and nudge theory (Brown, ICSE 2019).

--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -85,7 +85,7 @@ Priority: Respond to real usage data.
 ## Competitive Watch
 
 - **claude-reflect** (861 stars): If they add teaching or personas, Alfred's differentiation narrows. Alfred's defense: collective learning (network effects).
-- **learn-faster-kit** (139 stars): General learning tool, already in awesome-claude-code. Alfred's differentiation: development habits specifically + 6 professional personas.
+- **learn-faster-kit** (139 stars): General learning tool, already in awesome-claude-code. Alfred's differentiation: development habits specifically + 7 professional personas.
 - **SuperClaude** (22K stars): Power-user tool, different audience. Don't compete.
 - **Anthropic native features**: The existential threat. Watch for: native memory/corrections, user profiles, progressive onboarding, team config management. Any of these shipping natively narrows Alfred's value prop. Cross-tool export is the hedge.
 


### PR DESCRIPTION
## Summary
- Fix install command across 3 files (was `alfred@DrakeCaraker/alfred`, should be `alfred@alfred-marketplace`)
- Update persona count from 6 to 7 across 7 files (writer added in PR #34)
- Fix inflated test count: "192 tests" → "128 checks" (make check output)
- Add v0.3.2 changelog entry covering all session work
- Update CLAUDE.md check count from 123 to 128

## Context
Pre-marketplace audit found the install command was wrong (would fail for new users), persona count was stale, and changelog had no v0.3.x entries.

## Test plan
- [x] `make check` passes (128 checks)
- [x] `make audit` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)