### PR TITLE
docs: Phase 2 readiness fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,10 @@ In any Claude Code session:
 ```
 /plugin marketplace add DrakeCaraker/alfred
 /plugin install alfred@alfred-marketplace
+/reload-plugins
 ```
 
-Then open your project and type `/alfred:bootstrap`. Alfred works in any project.
+Then type `/alfred:bootstrap`. Alfred works in any project.
 
 **Starting a new project** (alternative — clones Alfred as a template):
 
@@ -184,6 +185,7 @@ Prompting tips: [`docs/PROMPTING_GUIDE.md`](docs/PROMPTING_GUIDE.md)
 | 4 | **Product Analytics** | Never peek at results before planned end date |
 | 5 | **BI Platform** | Never DROP production tables without backup |
 | 6 | **General** | Never commit .env files; run tests before pushing |
+| 7 | **Writer / Editor** | Never overwrite approved drafts; version explicitly |
 
 ---
 

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -71,6 +71,7 @@ Then inside Claude Code, type:
 ```
 /plugin marketplace add DrakeCaraker/alfred
 /plugin install alfred@alfred-marketplace
+/reload-plugins
 ```
 
 That's it — Alfred is now available in all your projects. Skip to Step 6.

--- a/docs/internal/BUSINESS_PLAN.md
+++ b/docs/internal/BUSINESS_PLAN.md
@@ -4,7 +4,7 @@
 
 ## Product
 
-Alfred is a Claude Code plugin that teaches AI-assisted development habits progressively, adapts to 6 professional domains, and compounds user corrections into team-wide automation. It's the only tool that combines teaching, personas, and self-improvement in one system.
+Alfred is a Claude Code plugin that teaches AI-assisted development habits progressively, adapts to 7 professional domains, and compounds user corrections into team-wide automation. It's the only tool that combines teaching, personas, and self-improvement in one system.
 
 ## Market Thesis
 
@@ -31,7 +31,7 @@ People fail at AI-assisted development because of missing habits, not missing AI
 
 **Why second:**
 - Adjacent to academics (many came from research)
-- 4 of 6 Alfred personas built for them
+- 5 of 7 Alfred personas built for them
 - High-value roles ($120-200K salaries = budget for tools)
 - Work in companies that become enterprise prospects
 
@@ -85,7 +85,7 @@ No dollar figures until paying design partners exist. Revenue projections based 
 
 1. **Behavioral science** — scaffolding, analogical transfer, choice architecture. Hard to replicate without understanding learning theory.
 2. **Collective learning network effects** — each user's corrections strengthen the system for everyone.
-3. **6 deep domain personas** — not generic, not configurable — purpose-built translations.
+3. **7 deep domain personas** — not generic, not configurable — purpose-built translations.
 4. **Full pipeline** — teaching → graduation → correction → rule → hook → collective. No competitor has all pieces.
 
 ### Key competitors to watch

--- a/docs/internal/ROADMAP.md
+++ b/docs/internal/ROADMAP.md
@@ -4,23 +4,23 @@
 
 ## Current State
 
-- **Version:** 0.2.0
+- **Version:** 0.3.2
 - **Stars:** 1 (creator only)
-- **Real users:** 0 (untested outside Alfred repo)
-- **Tests:** 192 (126 structural + 29 unit + 16 anonymizer + 21 PII scanner)
+- **Real users:** 0 (Phase 1 validated in dash-shap + fresh install test)
+- **Checks:** 128 via `make check`
 - **Commands:** 19
-- **Personas:** 6
-- **CLAUDE.md rules:** 8
+- **Personas:** 7
+- **CLAUDE.md rules:** 9
 
 ## Phase 1: Validate (Target: 2026-04-04)
 
 Priority: Prove Alfred works as a plugin before any distribution.
 
-- [ ] Test plugin install in dash-shap: `/plugin marketplace add DrakeCaraker/alfred`
-- [ ] Dog-food 3+ sessions with Alfred as a plugin in dash-shap
-- [ ] Document every friction point (missing features, broken paths, confusing UX)
-- [ ] Fix all P0 issues found during dog-fooding
-- [ ] Verify collective signal auto-submission works from a plugin project
+- [x] Test plugin install in dash-shap: `/plugin marketplace add DrakeCaraker/alfred`
+- [x] Dog-food 3+ sessions with Alfred as a plugin in dash-shap
+- [x] Document every friction point (missing features, broken paths, confusing UX)
+- [x] Fix all P0 issues found during dog-fooding (12 PRs: #34-#56)
+- [x] Verify collective signal auto-submission works from a plugin project
 - [ ] Add `CLAUDE_ENABLED=true` repo variable to activate CI autofix
 
 **Exit criteria:** Alfred works end-to-end as a plugin in a real project with zero manual workarounds.


### PR DESCRIPTION
## Summary
- Add `/reload-plugins` to install instructions in README and GETTING_STARTED — without this, fresh installs fail with "Unknown skill"
- Add writer persona (row 7) to README persona table
- Update roadmap: current state (v0.3.2, 128 checks, 7 personas), Phase 1 tasks checked off
- Update business plan: 6 → 7 personas in 3 locations

## Context
Pre-marketplace audit found the install flow was incomplete (missing reload step) and counts were stale across internal and external docs.

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)