### PR TITLE
fix: marketplace manifest schema + consent value proposition

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,16 +1,17 @@
 {
   "name": "alfred-marketplace",
-  "description": "Alfred plugin marketplace — AI coding assistant that teaches development habits",
   "owner": {
     "name": "Drake Caraker",
-    "url": "https://github.com/DrakeCaraker"
+    "email": "DrakeCaraker@users.noreply.github.com"
+  },
+  "metadata": {
+    "description": "Alfred plugin marketplace — AI coding assistant that teaches development habits"
   },
   "plugins": [
     {
       "name": "alfred",
-      "description": "Teaches development habits in your domain's language, then turns your corrections into permanent rules and automated guards. 6 personas, 8 habits, encrypted collective learning.",
-      "source": "./",
-      "version": "0.2.2"
+      "description": "Teaches development habits in your domain's language, then turns your corrections into permanent rules and automated guards. 7 personas, 8 habits, encrypted collective learning.",
+      "source": "./"
     }
   ]
 }

--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -428,35 +428,43 @@ Alfred collects anonymized data to improve. Show this disclosure and ask explici
 
 **For beginners:**
 ```
-One more thing — Alfred can collect anonymous information about which
-habits you're learning and how the system is working. This helps
-improve Alfred for everyone.
+One more thing — Alfred can collect anonymous information about how
+people learn and what corrections they make. Here's why this matters:
+
+Why opt in:
+  • When 3+ people make the same correction, it becomes a recommended
+    rule that helps everyone avoid the same mistake
+  • Habit data shows which lessons work and which need rewriting
+  • Your corrections literally improve Alfred for the next person
+
+How it's safe:
+  • Everything is encrypted (AES-256) before leaving your machine
+  • No names, emails, code, file paths, or project details — ever
+  • Company names are automatically stripped by the anonymizer
+  • You can see exactly what's collected: /pilot-consent
+  • Opt out anytime: /pilot-consent revoke
+  • Delete your data anytime: /pilot-delete
 
 What's collected (all anonymous and encrypted):
   • Which habits you've learned and how many sessions it took
   • How long sessions last (short/medium/long, not exact times)
   • Which commands you use (names only, never your code or files)
-  • What rules you create in CLAUDE.md (anonymized — company names removed)
-  • What automations you build (hooks, CI checks — purpose only, no code)
-
-What's NEVER collected:
-  • Your name, email, or any personal info
-  • Your code, file names, or project details
-  • Company names (automatically removed by the anonymizer)
-  • Anything that could identify you or your project
-
-Everything is encrypted before leaving your machine.
-You can opt out anytime by running /pilot-consent revoke.
+  • What rules you create in CLAUDE.md (anonymized)
+  • What automations you build (purpose only, no code)
 
 Is this okay? (yes/no)
 ```
 
 **For intermediate/advanced:**
 ```
-Alfred collects anonymized, encrypted signals: habit graduation patterns,
-CLAUDE.md rules (anonymized), session metadata, and automation patterns.
+Alfred collects anonymized, encrypted signals to improve the system.
+When 3+ users independently make the same correction, it becomes a
+recommended rule — your feedback literally shapes the tool for everyone.
+
+Collected: habit graduation patterns, anonymized CLAUDE.md rules,
+session metadata, automation patterns. All encrypted (AES-256).
 No code, paths, PII, or company names. See .pilot/README.md for details.
-Opt out anytime: /pilot-consent revoke.
+Inspect: /pilot-consent | Opt out: /pilot-consent revoke | Delete: /pilot-delete
 
 Enable data collection? (yes/no)
 ```

--- a/.claude/commands/pilot-consent.md
+++ b/.claude/commands/pilot-consent.md
@@ -17,6 +17,18 @@ $ARGUMENTS — optional: `revoke` to revoke consent, `status` to check current s
    ```
    === Alfred Data Collection ===
 
+   WHY OPT IN:
+     When 3+ people independently make the same correction, it becomes
+     a recommended rule — your feedback improves Alfred for everyone.
+     Habit data shows which lessons work and which need rewriting.
+     You make Alfred better; Alfred makes the next person better.
+
+   HOW IT'S SAFE:
+     Everything is encrypted (AES-256) before leaving your machine.
+     7 guard layers: schema design, PII scrubber, pre-commit hook,
+     pre-push hook, CI checks, branch protection, encryption.
+     You can inspect, export, or delete your data at any time.
+
    Alfred collects two types of anonymized data (both under one consent):
 
    TELEMETRY (session metadata):

--- a/commands/bootstrap.md
+++ b/commands/bootstrap.md
@@ -428,35 +428,43 @@ Alfred collects anonymized data to improve. Show this disclosure and ask explici
 
 **For beginners:**
 ```
-One more thing — Alfred can collect anonymous information about which
-habits you're learning and how the system is working. This helps
-improve Alfred for everyone.
+One more thing — Alfred can collect anonymous information about how
+people learn and what corrections they make. Here's why this matters:
+
+Why opt in:
+  • When 3+ people make the same correction, it becomes a recommended
+    rule that helps everyone avoid the same mistake
+  • Habit data shows which lessons work and which need rewriting
+  • Your corrections literally improve Alfred for the next person
+
+How it's safe:
+  • Everything is encrypted (AES-256) before leaving your machine
+  • No names, emails, code, file paths, or project details — ever
+  • Company names are automatically stripped by the anonymizer
+  • You can see exactly what's collected: /pilot-consent
+  • Opt out anytime: /pilot-consent revoke
+  • Delete your data anytime: /pilot-delete
 
 What's collected (all anonymous and encrypted):
   • Which habits you've learned and how many sessions it took
   • How long sessions last (short/medium/long, not exact times)
   • Which commands you use (names only, never your code or files)
-  • What rules you create in CLAUDE.md (anonymized — company names removed)
-  • What automations you build (hooks, CI checks — purpose only, no code)
-
-What's NEVER collected:
-  • Your name, email, or any personal info
-  • Your code, file names, or project details
-  • Company names (automatically removed by the anonymizer)
-  • Anything that could identify you or your project
-
-Everything is encrypted before leaving your machine.
-You can opt out anytime by running /pilot-consent revoke.
+  • What rules you create in CLAUDE.md (anonymized)
+  • What automations you build (purpose only, no code)
 
 Is this okay? (yes/no)
 ```
 
 **For intermediate/advanced:**
 ```
-Alfred collects anonymized, encrypted signals: habit graduation patterns,
-CLAUDE.md rules (anonymized), session metadata, and automation patterns.
+Alfred collects anonymized, encrypted signals to improve the system.
+When 3+ users independently make the same correction, it becomes a
+recommended rule — your feedback literally shapes the tool for everyone.
+
+Collected: habit graduation patterns, anonymized CLAUDE.md rules,
+session metadata, automation patterns. All encrypted (AES-256).
 No code, paths, PII, or company names. See .pilot/README.md for details.
-Opt out anytime: /pilot-consent revoke.
+Inspect: /pilot-consent | Opt out: /pilot-consent revoke | Delete: /pilot-delete
 
 Enable data collection? (yes/no)
 ```

--- a/commands/pilot-consent.md
+++ b/commands/pilot-consent.md
@@ -17,6 +17,18 @@ $ARGUMENTS — optional: `revoke` to revoke consent, `status` to check current s
    ```
    === Alfred Data Collection ===
 
+   WHY OPT IN:
+     When 3+ people independently make the same correction, it becomes
+     a recommended rule — your feedback improves Alfred for everyone.
+     Habit data shows which lessons work and which need rewriting.
+     You make Alfred better; Alfred makes the next person better.
+
+   HOW IT'S SAFE:
+     Everything is encrypted (AES-256) before leaving your machine.
+     7 guard layers: schema design, PII scrubber, pre-commit hook,
+     pre-push hook, CI checks, branch protection, encryption.
+     You can inspect, export, or delete your data at any time.
+
    Alfred collects two types of anonymized data (both under one consent):
 
    TELEMETRY (session metadata):


### PR DESCRIPTION
## Summary
- Fix marketplace.json: move `description` to `metadata.description` (fixes `claude plugin validate .`)
- Bootstrap consent: add "Why opt in" (collective learning benefit) and "How it's safe" (encryption, 7 guard layers)
- pilot-consent disclosure: add WHY OPT IN and HOW IT'S SAFE sections

## Test plan
- [x] `make check` passes
- [x] `make audit` passes
- [ ] CI passes
- [ ] `claude plugin validate .` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)