### PR TITLE
docs: add /reload-plugins to WHO_ITS_FOR install block

### DIFF
--- a/docs/WHO_ITS_FOR.md
+++ b/docs/WHO_ITS_FOR.md
@@ -123,6 +123,7 @@ Alfred is per-project but team-aware. Each member runs `/bootstrap` with their o
 ```
 /plugin marketplace add DrakeCaraker/alfred
 /plugin install alfred@alfred-marketplace
+/reload-plugins
 ```
 
 Then run `/alfred:bootstrap` in any project.


### PR DESCRIPTION
Last install doc missing the reload step. README and GETTING_STARTED already had it.