### PR TITLE
fix: ALFRED_ROOT resolution fallback for data collection pipeline

### DIFF
--- a/.claude/commands/bootstrap.md
+++ b/.claude/commands/bootstrap.md
@@ -400,6 +400,11 @@ Replace `<PLUGIN_HOOKS_PATH>` with the actual path to Alfred's hooks:
 
 Detect the correct path at bootstrap time and write absolute paths for plugin mode, relative paths for standalone mode.
 
+**Also write `.claude/.alfred-root`** with the resolved ALFRED_ROOT path (the directory containing `collective/signal_schema.yaml`). This allows hooks to find Alfred's scripts even when the walk-up marker search fails (e.g., in plugin-bootstrapped projects that don't have a `collective/` directory). Example:
+```bash
+echo "$RESOLVED_ALFRED_ROOT" > .claude/.alfred-root
+```
+
 If `.claude/settings.json` already exists, merge the hooks — do NOT overwrite existing hooks (the project may have its own).
 
 Do NOT overwrite existing `.gitignore` entries — only append missing patterns.

--- a/.claude/hooks/format-on-write.sh
+++ b/.claude/hooks/format-on-write.sh
@@ -23,12 +23,12 @@ case "$f" in
 esac
 
 # Read preferred formatter from alfred.yaml (if configured)
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -36,8 +36,11 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
-preferred=$("$ALFRED_ROOT/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
+preferred=$("${ALFRED_ROOT:-/dev/null}/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
 
 # If a specific formatter is configured, use it directly
 if [ "$preferred" != "auto" ] && [ "$preferred" != "none" ]; then

--- a/.claude/hooks/pilot-telemetry.sh
+++ b/.claude/hooks/pilot-telemetry.sh
@@ -23,12 +23,12 @@ if [ -z "$uuid" ]; then
 fi
 
 # Detect Alfred root for script references
-# Detect Alfred root: walk up from script location until we find the marker
+# Priority: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -36,6 +36,14 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    # Fallback: read stored path from bootstrap
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
+    # If still not found, hooks that need ALFRED_ROOT will silently skip
+    if [ -z "$ALFRED_ROOT" ]; then
+        ALFRED_ROOT=""
+    fi
 fi
 
 # Calculate duration bucket
@@ -153,12 +161,12 @@ PYEOF
 
 # Aggregate collective signals from current project's feedback memories
 # Use project_key (already computed above) to scope to this project only
-if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+if [ -n "$ALFRED_ROOT" ] && [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
     python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
 fi
 
 # Push pending signals with 30-minute debounce (Stop fires after every response)
-if [ -f ".claude/.collective-pending.json" ]; then
+if [ -n "$ALFRED_ROOT" ] && [ -f ".claude/.collective-pending.json" ]; then
     should_push=false
     push_marker=".claude/.last-signal-push"
     if [ ! -f "$push_marker" ]; then

--- a/.claude/hooks/pre-compact.sh
+++ b/.claude/hooks/pre-compact.sh
@@ -2,13 +2,12 @@
 # PreCompact hook: preserve context + push signals before compression
 echo "Alfred: preserving context before compression..." >&2
 
-# Detect Alfred root
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -16,6 +15,9 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
 
 # Check consent before any data operations

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -5,12 +5,12 @@
 echo "=== Alfred Session Warm-Up ===" >&2
 
 # Read configured main branch from alfred.yaml (default: main)
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -18,6 +18,9 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
 MAIN_BRANCH=$("$ALFRED_ROOT/scripts/alfred-config.sh" git.main_branch main 2>/dev/null)
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ target/
 .claude/.pilot-consent.json
 .claude/.pilot-identity.json
 .claude/.collective-pending.json
+.claude/.alfred-root
 
 # Telemetry data (per-user)
 .pilot/telemetry/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Key concern: rigor, reproducibility, citation accuracy, IRB compliance.
 ## Running
 
 ```bash
-make check    # Full validation: validate + lint + test (128 checks)
+make check    # Full validation: validate + lint + test (133 checks)
 make audit    # Deep security lint: injection, secrets, traps, sync
 make fix      # Auto-fix: sync commands + hooks + permissions
 ```

--- a/commands/bootstrap.md
+++ b/commands/bootstrap.md
@@ -400,6 +400,11 @@ Replace `<PLUGIN_HOOKS_PATH>` with the actual path to Alfred's hooks:
 
 Detect the correct path at bootstrap time and write absolute paths for plugin mode, relative paths for standalone mode.
 
+**Also write `.claude/.alfred-root`** with the resolved ALFRED_ROOT path (the directory containing `collective/signal_schema.yaml`). This allows hooks to find Alfred's scripts even when the walk-up marker search fails (e.g., in plugin-bootstrapped projects that don't have a `collective/` directory). Example:
+```bash
+echo "$RESOLVED_ALFRED_ROOT" > .claude/.alfred-root
+```
+
 If `.claude/settings.json` already exists, merge the hooks — do NOT overwrite existing hooks (the project may have its own).
 
 Do NOT overwrite existing `.gitignore` entries — only append missing patterns.

--- a/hooks/format-on-write.sh
+++ b/hooks/format-on-write.sh
@@ -23,12 +23,12 @@ case "$f" in
 esac
 
 # Read preferred formatter from alfred.yaml (if configured)
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -36,8 +36,11 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
-preferred=$("$ALFRED_ROOT/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
+preferred=$("${ALFRED_ROOT:-/dev/null}/scripts/alfred-config.sh" formatting.tool auto 2>/dev/null)
 
 # If a specific formatter is configured, use it directly
 if [ "$preferred" != "auto" ] && [ "$preferred" != "none" ]; then

--- a/hooks/pilot-telemetry.sh
+++ b/hooks/pilot-telemetry.sh
@@ -23,12 +23,12 @@ if [ -z "$uuid" ]; then
 fi
 
 # Detect Alfred root for script references
-# Detect Alfred root: walk up from script location until we find the marker
+# Priority: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -36,6 +36,14 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    # Fallback: read stored path from bootstrap
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
+    # If still not found, hooks that need ALFRED_ROOT will silently skip
+    if [ -z "$ALFRED_ROOT" ]; then
+        ALFRED_ROOT=""
+    fi
 fi
 
 # Calculate duration bucket
@@ -153,12 +161,12 @@ PYEOF
 
 # Aggregate collective signals from current project's feedback memories
 # Use project_key (already computed above) to scope to this project only
-if [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
+if [ -n "$ALFRED_ROOT" ] && [ -d "$memory_dir" ] && [ -f "$ALFRED_ROOT/collective/aggregator.py" ]; then
     python3 "$ALFRED_ROOT/collective/aggregator.py" "$memory_dir" --save .claude/.collective-pending.json >/dev/null 2>&1 || true
 fi
 
 # Push pending signals with 30-minute debounce (Stop fires after every response)
-if [ -f ".claude/.collective-pending.json" ]; then
+if [ -n "$ALFRED_ROOT" ] && [ -f ".claude/.collective-pending.json" ]; then
     should_push=false
     push_marker=".claude/.last-signal-push"
     if [ ! -f "$push_marker" ]; then

--- a/hooks/pre-compact.sh
+++ b/hooks/pre-compact.sh
@@ -2,13 +2,12 @@
 # PreCompact hook: preserve context + push signals before compression
 echo "Alfred: preserving context before compression..." >&2
 
-# Detect Alfred root
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -16,6 +15,9 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
 
 # Check consent before any data operations

--- a/hooks/session-start.sh
+++ b/hooks/session-start.sh
@@ -5,12 +5,12 @@
 echo "=== Alfred Session Warm-Up ===" >&2
 
 # Read configured main branch from alfred.yaml (default: main)
-# Detect Alfred root: walk up from script location until we find the marker
+# Detect Alfred root: CLAUDE_PLUGIN_ROOT > walk-up marker > .alfred-root file
 if [ -n "${CLAUDE_PLUGIN_ROOT:-}" ]; then
     ALFRED_ROOT="$CLAUDE_PLUGIN_ROOT"
 else
     _dir="$(cd "$(dirname "$0")" && pwd)"
-    ALFRED_ROOT="$_dir"
+    ALFRED_ROOT=""
     while [ "$_dir" != "/" ]; do
         if [ -f "$_dir/collective/signal_schema.yaml" ]; then
             ALFRED_ROOT="$_dir"
@@ -18,6 +18,9 @@ else
         fi
         _dir="$(dirname "$_dir")"
     done
+    if [ -z "$ALFRED_ROOT" ] && [ -f ".claude/.alfred-root" ]; then
+        ALFRED_ROOT=$(cat ".claude/.alfred-root" 2>/dev/null)
+    fi
 fi
 MAIN_BRANCH=$("$ALFRED_ROOT/scripts/alfred-config.sh" git.main_branch main 2>/dev/null)
 


### PR DESCRIPTION
## Summary
- Hooks in plugin-bootstrapped projects (like dash-shap) couldn't find Alfred's scripts because the walk-up marker search (`collective/signal_schema.yaml`) fails when the project doesn't have a `collective/` directory
- Added `.claude/.alfred-root` file fallback: bootstrap writes the resolved ALFRED_ROOT path, and all 4 hooks read it when the walk-up fails
- Guarded aggregator/push calls against empty ALFRED_ROOT to prevent silent failures

## Root cause
When Alfred is installed as a plugin and a user runs `/bootstrap`, the project's settings.json registers hooks pointing to `.claude/hooks/`. Those hooks use `dirname "$0"` + walk-up to find Alfred's root. But in user projects, there's no `collective/signal_schema.yaml` to find — the walk-up reaches `/` and ALFRED_ROOT stays empty. All downstream calls (aggregator, collective-sync push) silently fail.

## Test plan
- [x] `make check` — 133 passed, 0 failed
- [x] `make audit` — 0 failures, 0 warnings
- [ ] Re-bootstrap dash-shap to generate `.claude/.alfred-root`
- [ ] Verify telemetry hook fires and writes to `.pilot/telemetry/`
- [ ] Verify signals push to collective repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)