### PR TITLE
fix: collective ingest workflow PEM key handling

### DIFF
--- a/.github/workflows/collective-ingest.yml
+++ b/.github/workflows/collective-ingest.yml
@@ -79,8 +79,9 @@ jobs:
         if: steps.extract.outputs.valid == 'true'
         id: decrypt
         run: |
-          # Write private key from secret
-          echo "$ALFRED_COLLECTIVE_PRIVATE_KEY" > /tmp/private.pem
+          # Write private key from secret (printf preserves PEM newlines)
+          printf '%s\n' "$ALFRED_COLLECTIVE_PRIVATE_KEY" > /tmp/private.pem
+          chmod 600 /tmp/private.pem
 
           # Decode base64
           base64 -d /tmp/aes_key.b64 > /tmp/aes_key.enc
@@ -116,7 +117,7 @@ jobs:
           ALLOWED_TYPES = ['correction','rule','graduation','automation','gap']
           ALLOWED_HABITS = ['context_before_action','scope_before_work','save_points','safe_experimentation','one_change_one_test','automated_recovery','provenance','self_improvement']
           ALLOWED_LEVELS = ['beginner','intermediate','advanced']
-          ALLOWED_PERSONAS = ['ml-ds','research','business-analytics','product-analytics','platform-bi','general','unknown']
+          ALLOWED_PERSONAS = ['ml-ds','research','business-analytics','product-analytics','platform-bi','general','writer','unknown']
 
           with open('/tmp/new_signals.json') as f:
               data = json.load(f)


### PR DESCRIPTION
## Summary
- `echo` mangles PEM private key newlines causing `Could not read private key` on every signal ingest
- Switched to `printf '%s\n'` which preserves multi-line content
- Added `chmod 600` for key file security
- Added `writer` to allowed personas (was missing since persona was added in v0.3.0)

## Root cause
Line 83: `echo "$ALFRED_COLLECTIVE_PRIVATE_KEY" > /tmp/private.pem` — GitHub Actions secrets preserve newlines in the variable, but `echo` with double quotes can still mangle PEM format depending on shell behavior and key content. `printf '%s\n'` is the reliable way to write multi-line secrets.

## Test plan
- [ ] Merge and re-open one of the closed signal issues to trigger ingest
- [ ] Verify workflow passes decrypt step

🤖 Generated with [Claude Code](https://claude.com/claude-code)