### PR TITLE
fix: restore PEM newlines in collective ingest

### DIFF
--- a/.github/workflows/collective-ingest.yml
+++ b/.github/workflows/collective-ingest.yml
@@ -80,16 +80,9 @@ jobs:
         id: decrypt
         run: |
           # Write private key from secret
-          # Use printenv to avoid any shell interpolation issues
-          printenv ALFRED_COLLECTIVE_PRIVATE_KEY > /tmp/private.pem
+          # GitHub secrets store PEM as single line with literal \n — restore newlines
+          echo "$ALFRED_COLLECTIVE_PRIVATE_KEY" | sed 's/\\n/\n/g' > /tmp/private.pem
           chmod 600 /tmp/private.pem
-
-          # Debug: check PEM format (no content leaked)
-          echo "PEM file size: $(wc -c < /tmp/private.pem) bytes"
-          echo "PEM line count: $(wc -l < /tmp/private.pem) lines"
-          echo "First line: $(head -1 /tmp/private.pem)"
-          echo "Last line: $(tail -1 /tmp/private.pem)"
-          openssl rsa -in /tmp/private.pem -check -noout 2>&1 || echo "RSA check failed"
 
           # Decode base64
           base64 -d /tmp/aes_key.b64 > /tmp/aes_key.enc


### PR DESCRIPTION
## Summary
GitHub secrets store multi-line PEM keys as single-line with literal `\n`. Previous attempts (`echo`, `printf`, `printenv`) all wrote 6543 bytes on 1 line. Now uses `sed 's/\\n/\n/g'` to restore actual newlines.

## Evidence
Debug logging showed: `PEM line count: 1 lines` / `PEM file size: 6543 bytes` — confirms the key content is there but newlines are literal `\n` strings.

## Test plan
- [ ] Merge, reopen issue #71, verify ingest passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)