### PR TITLE
fix: use Python for PEM key handling in collective ingest

### DIFF
--- a/.github/workflows/collective-ingest.yml
+++ b/.github/workflows/collective-ingest.yml
@@ -79,10 +79,25 @@ jobs:
         if: steps.extract.outputs.valid == 'true'
         id: decrypt
         run: |
-          # Write private key from secret
-          # GitHub secrets store PEM as single line with literal \n — restore newlines
-          echo "$ALFRED_COLLECTIVE_PRIVATE_KEY" | sed 's/\\n/\n/g' > /tmp/private.pem
+          # Write private key from secret using Python for reliable newline handling
+          # GitHub secrets may store PEM with literal \n, \\n, or stripped newlines
+          python3 -c "
+          import os
+          key = os.environ['ALFRED_COLLECTIVE_PRIVATE_KEY']
+          # Restore newlines from any escaped format
+          for token in ['\\\\n', '\\n']:
+              key = key.replace(token, chr(10))
+          with open('/tmp/private.pem', 'w') as f:
+              f.write(key.strip() + chr(10))
+          "
           chmod 600 /tmp/private.pem
+
+          # Verify key is valid before proceeding
+          echo "PEM lines: $(wc -l < /tmp/private.pem)"
+          openssl rsa -in /tmp/private.pem -check -noout 2>&1 || {
+            echo "Key validation failed. Trying PKCS8 format..."
+            openssl pkey -in /tmp/private.pem -check -noout 2>&1 || echo "PKCS8 check also failed"
+          }
 
           # Decode base64
           base64 -d /tmp/aes_key.b64 > /tmp/aes_key.enc


### PR DESCRIPTION
Shell approaches all failed. Python reliably handles all newline escape formats. Includes key validation diagnostics.